### PR TITLE
(chore) remove Platform ifdefs

### DIFF
--- a/src/Bead1dProfile.cpp
+++ b/src/Bead1dProfile.cpp
@@ -25,52 +25,11 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 #include "LogTextMessage.h"
 
 
-#if Platform == DECALPHA 
-#elif Platform == SGICC
-	#define BILAYER_NO_USE_VALARRAY 1
-#elif Platform == CRAYJ90
-	#define BILAYER_NO_USE_VALARRAY 1
-#elif Platform == BORLAND6
 	using std::transform;
 	using std::slice;
 	using std::gslice;
 	using std::find;
 	using std::find_if;
-#elif Platform == I7XEON
-	using std::transform;
-	using std::slice;
-	using std::gslice;
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-	using std::transform;
-	using std::slice;
-	using std::gslice;
-	using std::find;
-	using std::find_if;
-#elif Platform == XCMAC
-	using std::transform;
-	using std::slice;
-	using std::gslice;
-	using std::find;
-	using std::find_if;
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else							
-	using std::transform;
-	using std::slice;
-	using std::gslice;
-	using std::find;
-	using std::find_if;
-#endif					
 
 
 //////////////////////////////////////////////////////////////////////

--- a/src/Bilayer.cpp
+++ b/src/Bilayer.cpp
@@ -51,52 +51,11 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 
 
-#if Platform == DECALPHA 
-#elif Platform == SGICC
-	#define BILAYER_NO_USE_VALARRAY 1
-#elif Platform == CRAYJ90
-	#define BILAYER_NO_USE_VALARRAY 1
-#elif Platform == BORLAND6
 	using std::transform;
 	using std::slice;
 	using std::gslice;
 	using std::find;
 	using std::find_if;
-#elif Platform == I7XEON
-	using std::transform;
-	using std::slice;
-	using std::gslice;
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-	using std::transform;
-	using std::slice;
-	using std::gslice;
-	using std::find;
-	using std::find_if;
-#elif Platform == XCMAC
-	using std::transform;
-	using std::slice;
-	using std::gslice;
-	using std::find;
-	using std::find_if;
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else							
-	using std::transform;
-	using std::slice;
-	using std::gslice;
-	using std::find;
-	using std::find_if;
-#endif					
 
 
 //////////////////////////////////////////////////////////////////////

--- a/src/Builder.cpp
+++ b/src/Builder.cpp
@@ -37,40 +37,6 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 // STL using declarations
 
-#if Platform == DECALPHA 
-	using std::max_element;
-	using std::random_shuffle;
-#elif Platform == SGICC
-	using std::max_element;
-	using std::random_shuffle;
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
-	using std::max_element;
-	using std::random_shuffle;
-#elif Platform == I7XEON
-	using std::max_element;
-	using std::random_shuffle;
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-	using std::max_element;
-	using std::random_shuffle;
-    using std::find;
-#elif Platform == XCMAC
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else							
-	using std::max_element;
-	using std::random_shuffle;
-#endif					
 
 
 // Uncomment the next flag to recreate the previous (wrong) normalisation for the

--- a/src/CNTCell.cpp
+++ b/src/CNTCell.cpp
@@ -88,14 +88,6 @@ const zArray2dDouble* CCNTCell::m_pvvSCRange = 0;
 
 // Platform-dependent initialisation of static arrays
 
-#if Platform == DECALPHA 
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
-#elif Platform == I7XEON
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
 
 zArray2dDouble	     CCNTCell::m_vvConsInt;
 zArray2dDouble	     CCNTCell::m_vvDissInt;
@@ -112,54 +104,6 @@ zArray2dDouble	     CCNTCell::m_vvLJSlope;
 zArray2dDouble	     CCNTCell::m_vvSCDelta;
 zArray2dDouble	     CCNTCell::m_vvSCSlope;
 
-#elif Platform == XCMAC
-
-zArray2dDouble	     CCNTCell::m_vvConsInt;
-zArray2dDouble	     CCNTCell::m_vvDissInt;
-zArray2dDouble	     CCNTCell::m_vvLGInt;
-zArray2dDouble	     CCNTCell::m_vvConsIntBackup;
-zArray2dDouble	     CCNTCell::m_vvDissIntBackup;
-zArray2dDouble	     CCNTCell::m_vvLGIntBackup;
-zArray2dDouble	     CCNTCell::m_vvLJDepth;
-zArray2dDouble	     CCNTCell::m_vvLJRange;
-zArray2dDouble	     CCNTCell::m_vvSCDepth;
-zArray2dDouble	     CCNTCell::m_vvSCRange;
-zArray2dDouble	     CCNTCell::m_vvLJDelta;
-zArray2dDouble	     CCNTCell::m_vvLJSlope;
-zArray2dDouble	     CCNTCell::m_vvSCDelta;
-zArray2dDouble	     CCNTCell::m_vvSCSlope;
-
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else 
-
-// Static arrays to hold the above data without a dereference being needed
-// for every access.
-
-zArray2dDouble	     CCNTCell::m_vvConsInt		  = 0.0;
-zArray2dDouble	     CCNTCell::m_vvDissInt		  = 0.0;
-zArray2dDouble	     CCNTCell::m_vvLGInt		  = 0.0;
-zArray2dDouble	     CCNTCell::m_vvConsIntBackup  = 0.0;
-zArray2dDouble	     CCNTCell::m_vvDissIntBackup  = 0.0;
-zArray2dDouble	     CCNTCell::m_vvLGIntBackup    = 0.0;
-zArray2dDouble	     CCNTCell::m_vvLJDepth		  = 0.0;
-zArray2dDouble	     CCNTCell::m_vvLJRange		  = 0.0;
-zArray2dDouble	     CCNTCell::m_vvSCDepth		  = 0.0;
-zArray2dDouble	     CCNTCell::m_vvSCRange	  	  = 0.0;
-zArray2dDouble	     CCNTCell::m_vvLJDelta		  = 0.0;
-zArray2dDouble	     CCNTCell::m_vvLJSlope		  = 0.0;
-zArray2dDouble	     CCNTCell::m_vvSCDelta		  = 0.0;
-zArray2dDouble	     CCNTCell::m_vvSCSlope		  = 0.0;
-
-#endif
 
 // Function to set the static member variable that holds a pointer to the
 // CMonitor object. This is used inside the force calculation loop to pass
@@ -1684,9 +1628,6 @@ void CCNTCell::UpdatePos()
 	// However, the Cray list<>::erase function does not return the next iterator
 	// so we have to provide a method for incrementing it manually.
 
-#if Platform == CRAYJ90
-	BeadListIterator nextBead = NULL;
-#endif
 
 	double dx[3];
 
@@ -1842,14 +1783,7 @@ void CCNTCell::UpdatePos()
 						}
 						(*iterBead)->SetNotMovable();
 						m_aNNCells[26]->m_lBeads.push_front((*iterBead));
-#if Platform == CRAYJ90
-						nextBead = iterBead;
-						nextBead++;
-						m_lBeads.erase(iterBead);
-						iterBead = nextBead;
-#else
 						iterBead = m_lBeads.erase(iterBead);
-#endif
 					}
 					else if( (*iterBead)->m_Pos[2] < m_BLCoord[2] )	// bead moves DTR
 					{
@@ -1864,14 +1798,7 @@ void CCNTCell::UpdatePos()
 						}
 						(*iterBead)->SetNotMovable();
 						m_aNNCells[8]->m_lBeads.push_front((*iterBead));
-#if Platform == CRAYJ90
-						nextBead = iterBead;
-						nextBead++;
-						m_lBeads.erase(iterBead);
-						iterBead = nextBead;
-#else
 						iterBead = m_lBeads.erase(iterBead);
-#endif
 					}
 					else	// bead moves TR
 					{
@@ -1884,14 +1811,7 @@ void CCNTCell::UpdatePos()
 						}
 						(*iterBead)->SetNotMovable();
 						m_aNNCells[17]->m_lBeads.push_front((*iterBead));
-#if Platform == CRAYJ90
-						nextBead = iterBead;
-						nextBead++;
-						m_lBeads.erase(iterBead);
-						iterBead = nextBead;
-#else
 						iterBead = m_lBeads.erase(iterBead);
-#endif
 					}
 #elif SimDimension == 2
 					if(m_bExternal && m_aNNCells[8]->IsExternal())
@@ -1903,14 +1823,7 @@ void CCNTCell::UpdatePos()
 					}
 					(*iterBead)->SetNotMovable();
 					m_aNNCells[8]->m_lBeads.push_front((*iterBead));
-#if Platform == CRAYJ90
-						nextBead = iterBead;
-						nextBead++;
-						m_lBeads.erase(iterBead);
-						iterBead = nextBead;
-#else
 						iterBead = m_lBeads.erase(iterBead);
-#endif
 #endif
 				}
 				else if( (*iterBead)->m_Pos[1] < m_BLCoord[1] )
@@ -1929,14 +1842,7 @@ void CCNTCell::UpdatePos()
 						}
 						(*iterBead)->SetNotMovable();
 						m_aNNCells[20]->m_lBeads.push_front((*iterBead));
-#if Platform == CRAYJ90
-						nextBead = iterBead;
-						nextBead++;
-						m_lBeads.erase(iterBead);
-						iterBead = nextBead;
-#else
 						iterBead = m_lBeads.erase(iterBead);
-#endif
 					}
 					else if( (*iterBead)->m_Pos[2] < m_BLCoord[2] )	// bead moves DBR
 					{
@@ -1951,14 +1857,7 @@ void CCNTCell::UpdatePos()
 						}
 						(*iterBead)->SetNotMovable();
 						m_aNNCells[2]->m_lBeads.push_front((*iterBead));
-#if Platform == CRAYJ90
-						nextBead = iterBead;
-						nextBead++;
-						m_lBeads.erase(iterBead);
-						iterBead = nextBead;
-#else
 						iterBead = m_lBeads.erase(iterBead);
-#endif
 					}
 					else	// bead moves BR
 					{
@@ -1971,14 +1870,7 @@ void CCNTCell::UpdatePos()
 						}
 						(*iterBead)->SetNotMovable();
 						m_aNNCells[11]->m_lBeads.push_front((*iterBead));
-#if Platform == CRAYJ90
-						nextBead = iterBead;
-						nextBead++;
-						m_lBeads.erase(iterBead);
-						iterBead = nextBead;
-#else
 						iterBead = m_lBeads.erase(iterBead);
-#endif
 					}
 #elif SimDimension == 2
 					if(m_bExternal && m_aNNCells[2]->IsExternal())
@@ -1990,14 +1882,7 @@ void CCNTCell::UpdatePos()
 					}
 						(*iterBead)->SetNotMovable();
 					m_aNNCells[2]->m_lBeads.push_front((*iterBead));
-#if Platform == CRAYJ90
-						nextBead = iterBead;
-						nextBead++;
-						m_lBeads.erase(iterBead);
-						iterBead = nextBead;
-#else
 						iterBead = m_lBeads.erase(iterBead);
-#endif
 #endif
 				}
 				else	// no change in Y direction
@@ -2014,14 +1899,7 @@ void CCNTCell::UpdatePos()
 						}
 						(*iterBead)->SetNotMovable();
 						m_aNNCells[23]->m_lBeads.push_front((*iterBead));
-#if Platform == CRAYJ90
-						nextBead = iterBead;
-						nextBead++;
-						m_lBeads.erase(iterBead);
-						iterBead = nextBead;
-#else
 						iterBead = m_lBeads.erase(iterBead);
-#endif
 					}
 					else if( (*iterBead)->m_Pos[2] < m_BLCoord[2] )	// bead moves DR
 					{
@@ -2034,14 +1912,7 @@ void CCNTCell::UpdatePos()
 						}
 						(*iterBead)->SetNotMovable();
 						m_aNNCells[5]->m_lBeads.push_front((*iterBead));
-#if Platform == CRAYJ90
-						nextBead = iterBead;
-						nextBead++;
-						m_lBeads.erase(iterBead);
-						iterBead = nextBead;
-#else
 						iterBead = m_lBeads.erase(iterBead);
-#endif
 					}
 					else	// bead moves R
 					{
@@ -2052,14 +1923,7 @@ void CCNTCell::UpdatePos()
 						}
 						(*iterBead)->SetNotMovable();
 						m_aNNCells[14]->m_lBeads.push_front((*iterBead));
-#if Platform == CRAYJ90
-						nextBead = iterBead;
-						nextBead++;
-						m_lBeads.erase(iterBead);
-						iterBead = nextBead;
-#else
 						iterBead = m_lBeads.erase(iterBead);
-#endif
 					}
 #elif SimDimension == 2
 					if(m_bExternal && m_aNNCells[5]->IsExternal())
@@ -2069,14 +1933,7 @@ void CCNTCell::UpdatePos()
 					}
 					(*iterBead)->SetNotMovable();
 					m_aNNCells[5]->m_lBeads.push_front((*iterBead));
-#if Platform == CRAYJ90
-						nextBead = iterBead;
-						nextBead++;
-						m_lBeads.erase(iterBead);
-						iterBead = nextBead;
-#else
 						iterBead = m_lBeads.erase(iterBead);
-#endif
 #endif
 				}
 			}
@@ -2098,14 +1955,7 @@ void CCNTCell::UpdatePos()
 						}
 						(*iterBead)->SetNotMovable();
 						m_aNNCells[24]->m_lBeads.push_front((*iterBead));
-#if Platform == CRAYJ90
-						nextBead = iterBead;
-						nextBead++;
-						m_lBeads.erase(iterBead);
-						iterBead = nextBead;
-#else
 						iterBead = m_lBeads.erase(iterBead);
-#endif
 					}
 					else if( (*iterBead)->m_Pos[2] < m_BLCoord[2] )	// bead moves DTL
 					{
@@ -2120,14 +1970,7 @@ void CCNTCell::UpdatePos()
 						}
 						(*iterBead)->SetNotMovable();
 						m_aNNCells[6]->m_lBeads.push_front((*iterBead));
-#if Platform == CRAYJ90
-						nextBead = iterBead;
-						nextBead++;
-						m_lBeads.erase(iterBead);
-						iterBead = nextBead;
-#else
 						iterBead = m_lBeads.erase(iterBead);
-#endif
 					}
 					else	// bead moves TL
 					{
@@ -2140,14 +1983,7 @@ void CCNTCell::UpdatePos()
 						}
 						(*iterBead)->SetNotMovable();
 						m_aNNCells[15]->m_lBeads.push_front((*iterBead));
-#if Platform == CRAYJ90
-						nextBead = iterBead;
-						nextBead++;
-						m_lBeads.erase(iterBead);
-						iterBead = nextBead;
-#else
 						iterBead = m_lBeads.erase(iterBead);
-#endif
 					}
 #elif SimDimension == 2
 					if(m_bExternal && m_aNNCells[6]->IsExternal())
@@ -2159,14 +1995,7 @@ void CCNTCell::UpdatePos()
 					}
 					(*iterBead)->SetNotMovable();
 					m_aNNCells[6]->m_lBeads.push_front((*iterBead));
-#if Platform == CRAYJ90
-						nextBead = iterBead;
-						nextBead++;
-						m_lBeads.erase(iterBead);
-						iterBead = nextBead;
-#else
 						iterBead = m_lBeads.erase(iterBead);
-#endif
 #endif
 				}
 				else if( (*iterBead)->m_Pos[1] < m_BLCoord[1] )	
@@ -2185,14 +2014,7 @@ void CCNTCell::UpdatePos()
 						}
 						(*iterBead)->SetNotMovable();
 						m_aNNCells[18]->m_lBeads.push_front((*iterBead));
-#if Platform == CRAYJ90
-						nextBead = iterBead;
-						nextBead++;
-						m_lBeads.erase(iterBead);
-						iterBead = nextBead;
-#else
 						iterBead = m_lBeads.erase(iterBead);
-#endif
 					}
 					else if( (*iterBead)->m_Pos[2] < m_BLCoord[2] )	// bead moves DBL
 					{
@@ -2207,14 +2029,7 @@ void CCNTCell::UpdatePos()
 						}
 						(*iterBead)->SetNotMovable();
 						m_aNNCells[0]->m_lBeads.push_front((*iterBead));
-#if Platform == CRAYJ90
-						nextBead = iterBead;
-						nextBead++;
-						m_lBeads.erase(iterBead);
-						iterBead = nextBead;
-#else
 						iterBead = m_lBeads.erase(iterBead);
-#endif
 					}
 					else	// bead moves BL
 					{
@@ -2227,14 +2042,7 @@ void CCNTCell::UpdatePos()
 						}
 						(*iterBead)->SetNotMovable();
 						m_aNNCells[9]->m_lBeads.push_front((*iterBead));
-#if Platform == CRAYJ90
-						nextBead = iterBead;
-						nextBead++;
-						m_lBeads.erase(iterBead);
-						iterBead = nextBead;
-#else
 						iterBead = m_lBeads.erase(iterBead);
-#endif
 					}
 #elif SimDimension == 2
 					if(m_bExternal && m_aNNCells[0]->IsExternal())
@@ -2246,14 +2054,7 @@ void CCNTCell::UpdatePos()
 					}
 					(*iterBead)->SetNotMovable();
 					m_aNNCells[0]->m_lBeads.push_front((*iterBead));
-#if Platform == CRAYJ90
-						nextBead = iterBead;
-						nextBead++;
-						m_lBeads.erase(iterBead);
-						iterBead = nextBead;
-#else
 						iterBead = m_lBeads.erase(iterBead);
-#endif
 #endif
 				}
 				else	// no change in Y direction
@@ -2270,14 +2071,7 @@ void CCNTCell::UpdatePos()
 						}
 						(*iterBead)->SetNotMovable();
 						m_aNNCells[21]->m_lBeads.push_front((*iterBead));
-#if Platform == CRAYJ90
-						nextBead = iterBead;
-						nextBead++;
-						m_lBeads.erase(iterBead);
-						iterBead = nextBead;
-#else
 						iterBead = m_lBeads.erase(iterBead);
-#endif
 					}
 					else if( (*iterBead)->m_Pos[2] < m_BLCoord[2] )	// bead moves DL
 					{
@@ -2290,14 +2084,7 @@ void CCNTCell::UpdatePos()
 						}
 						(*iterBead)->SetNotMovable();
 						m_aNNCells[3]->m_lBeads.push_front((*iterBead));
-#if Platform == CRAYJ90
-						nextBead = iterBead;
-						nextBead++;
-						m_lBeads.erase(iterBead);
-						iterBead = nextBead;
-#else
 						iterBead = m_lBeads.erase(iterBead);
-#endif
 					}
 					else	// bead moves L
 					{
@@ -2308,14 +2095,7 @@ void CCNTCell::UpdatePos()
 						}
 						(*iterBead)->SetNotMovable();
 						m_aNNCells[12]->m_lBeads.push_front((*iterBead));
-#if Platform == CRAYJ90
-						nextBead = iterBead;
-						nextBead++;
-						m_lBeads.erase(iterBead);
-						iterBead = nextBead;
-#else
 						iterBead = m_lBeads.erase(iterBead);
-#endif
 					}
 #elif SimDimension == 2
 					if(m_bExternal && m_aNNCells[3]->IsExternal())
@@ -2325,14 +2105,7 @@ void CCNTCell::UpdatePos()
 					}
 					(*iterBead)->SetNotMovable();
 					m_aNNCells[3]->m_lBeads.push_front((*iterBead));
-#if Platform == CRAYJ90
-						nextBead = iterBead;
-						nextBead++;
-						m_lBeads.erase(iterBead);
-						iterBead = nextBead;
-#else
 						iterBead = m_lBeads.erase(iterBead);
-#endif
 #endif
 				}
 			}
@@ -2352,14 +2125,7 @@ void CCNTCell::UpdatePos()
 						}
 						(*iterBead)->SetNotMovable();
 						m_aNNCells[25]->m_lBeads.push_front((*iterBead));
-#if Platform == CRAYJ90
-						nextBead = iterBead;
-						nextBead++;
-						m_lBeads.erase(iterBead);
-						iterBead = nextBead;
-#else
 						iterBead = m_lBeads.erase(iterBead);
-#endif
 					}
 					else if( (*iterBead)->m_Pos[2] < m_BLCoord[2] )	// bead moves DT
 					{
@@ -2372,14 +2138,7 @@ void CCNTCell::UpdatePos()
 						}
 						(*iterBead)->SetNotMovable();
 						m_aNNCells[7]->m_lBeads.push_front((*iterBead));
-#if Platform == CRAYJ90
-						nextBead = iterBead;
-						nextBead++;
-						m_lBeads.erase(iterBead);
-						iterBead = nextBead;
-#else
 						iterBead = m_lBeads.erase(iterBead);
-#endif
 					}
 					else	// bead moves T
 					{
@@ -2390,14 +2149,7 @@ void CCNTCell::UpdatePos()
 						}
 						(*iterBead)->SetNotMovable();
 						m_aNNCells[16]->m_lBeads.push_front((*iterBead));
-#if Platform == CRAYJ90
-						nextBead = iterBead;
-						nextBead++;
-						m_lBeads.erase(iterBead);
-						iterBead = nextBead;
-#else
 						iterBead = m_lBeads.erase(iterBead);
-#endif
 					}
 #elif SimDimension == 2
 					if(m_bExternal && m_aNNCells[7]->IsExternal())
@@ -2407,14 +2159,7 @@ void CCNTCell::UpdatePos()
 					}
 					(*iterBead)->SetNotMovable();
 					m_aNNCells[7]->m_lBeads.push_front((*iterBead));
-#if Platform == CRAYJ90
-						nextBead = iterBead;
-						nextBead++;
-						m_lBeads.erase(iterBead);
-						iterBead = nextBead;
-#else
 						iterBead = m_lBeads.erase(iterBead);
-#endif
 #endif
 				}
 				else if( (*iterBead)->m_Pos[1] < m_BLCoord[1] )
@@ -2431,14 +2176,7 @@ void CCNTCell::UpdatePos()
 						}
 						(*iterBead)->SetNotMovable();
 						m_aNNCells[19]->m_lBeads.push_front((*iterBead));
-#if Platform == CRAYJ90
-						nextBead = iterBead;
-						nextBead++;
-						m_lBeads.erase(iterBead);
-						iterBead = nextBead;
-#else
 						iterBead = m_lBeads.erase(iterBead);
-#endif
 					}
 					else if( (*iterBead)->m_Pos[2] < m_BLCoord[2] )	// bead moves DB
 					{
@@ -2451,14 +2189,7 @@ void CCNTCell::UpdatePos()
 						}
 						(*iterBead)->SetNotMovable();
 						m_aNNCells[1]->m_lBeads.push_front((*iterBead));
-#if Platform == CRAYJ90
-						nextBead = iterBead;
-						nextBead++;
-						m_lBeads.erase(iterBead);
-						iterBead = nextBead;
-#else
 						iterBead = m_lBeads.erase(iterBead);
-#endif
 					}
 					else	// bead moves B
 					{
@@ -2469,14 +2200,7 @@ void CCNTCell::UpdatePos()
 						}
 						(*iterBead)->SetNotMovable();
 						m_aNNCells[10]->m_lBeads.push_front((*iterBead));
-#if Platform == CRAYJ90
-						nextBead = iterBead;
-						nextBead++;
-						m_lBeads.erase(iterBead);
-						iterBead = nextBead;
-#else
 						iterBead = m_lBeads.erase(iterBead);
-#endif
 					}
 #elif SimDimension == 2
 					if(m_bExternal && m_aNNCells[1]->IsExternal())
@@ -2486,14 +2210,7 @@ void CCNTCell::UpdatePos()
 					}
 					(*iterBead)->SetNotMovable();
 					m_aNNCells[1]->m_lBeads.push_front((*iterBead));
-#if Platform == CRAYJ90
-						nextBead = iterBead;
-						nextBead++;
-						m_lBeads.erase(iterBead);
-						iterBead = nextBead;
-#else
 						iterBead = m_lBeads.erase(iterBead);
-#endif
 #endif
 				}
 				else	// no change in X, Y directions
@@ -2508,14 +2225,7 @@ void CCNTCell::UpdatePos()
 						}
 						(*iterBead)->SetNotMovable();
 						m_aNNCells[22]->m_lBeads.push_front((*iterBead));
-#if Platform == CRAYJ90
-						nextBead = iterBead;
-						nextBead++;
-						m_lBeads.erase(iterBead);
-						iterBead = nextBead;
-#else
 						iterBead = m_lBeads.erase(iterBead);
-#endif
 					}
 					else if( (*iterBead)->m_Pos[2] < m_BLCoord[2] )	// bead moves D
 					{
@@ -2526,14 +2236,7 @@ void CCNTCell::UpdatePos()
 						}
 						(*iterBead)->SetNotMovable();
 						m_aNNCells[4]->m_lBeads.push_front((*iterBead));
-#if Platform == CRAYJ90
-						nextBead = iterBead;
-						nextBead++;
-						m_lBeads.erase(iterBead);
-						iterBead = nextBead;
-#else
 						iterBead = m_lBeads.erase(iterBead);
-#endif
 					}
 					else
 					{

--- a/src/CompositeBilayer.cpp
+++ b/src/CompositeBilayer.cpp
@@ -53,44 +53,9 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 #include "aaStressTensorPoint.h"		// Actual stress tensor components at a point
 
 
-#if Platform == DECALPHA 
-#elif Platform == SGICC
-	#define BILAYER_NO_USE_VALARRAY 1
-#elif Platform == CRAYJ90
-	#define BILAYER_NO_USE_VALARRAY 1
-#elif Platform == BORLAND6
 	using std::transform;
 	using std::slice;
 	using std::gslice;
-#elif Platform == I7XEON
-	using std::transform;
-	using std::slice;
-	using std::gslice;
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-	using std::transform;
-	using std::slice;
-	using std::gslice;
-#elif Platform == XCMAC
-	using std::transform;
-	using std::slice;
-	using std::gslice;
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else							
-	using std::transform;
-	using std::slice;
-	using std::gslice;
-#endif					
 
 //////////////////////////////////////////////////////////////////////
 // Construction/Destruction

--- a/src/DensityField1d.cpp
+++ b/src/DensityField1d.cpp
@@ -24,52 +24,11 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 #include "aaRegionToType.h"
 
 
-#if Platform == DECALPHA 
-#elif Platform == SGICC
-	#define BILAYER_NO_USE_VALARRAY 1
-#elif Platform == CRAYJ90
-	#define BILAYER_NO_USE_VALARRAY 1
-#elif Platform == BORLAND6
 	using std::transform;
 	using std::slice;
 	using std::gslice;
 	using std::find;
 	using std::find_if;
-#elif Platform == I7XEON
-	using std::transform;
-	using std::slice;
-	using std::gslice;
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-	using std::transform;
-	using std::slice;
-	using std::gslice;
-	using std::find;
-	using std::find_if;
-#elif Platform == XCMAC
-	using std::transform;
-	using std::slice;
-	using std::gslice;
-	using std::find;
-	using std::find_if;
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else							
-	using std::transform;
-	using std::slice;
-	using std::gslice;
-	using std::find;
-	using std::find_if;
-#endif					
 
 
 //////////////////////////////////////////////////////////////////////

--- a/src/Domain2d.cpp
+++ b/src/Domain2d.cpp
@@ -27,37 +27,6 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 // STL using declarations
 
-#if Platform == DECALPHA 
-#elif Platform == SGICC
-	#define BILAYER_NO_USE_VALARRAY 1
-#elif Platform == CRAYJ90
-	#define BILAYER_NO_USE_VALARRAY 1
-#elif Platform == BORLAND6
-	using std::transform;
-	using std::find;
-	using std::find_if;
-	using std::accumulate;
-#elif Platform == I7XEON
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-#elif Platform == XCMAC
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else							
-	using std::transform;
-	using std::find;
-	using std::find_if;
-	using std::accumulate;
-#endif					
 
 
 //////////////////////////////////////////////////////////////////////

--- a/src/ExperimentDefs.h
+++ b/src/ExperimentDefs.h
@@ -24,30 +24,7 @@
 #define ExperimentEnabled   1
 #define ExperimentDisabled  2
 
-#if Platform   == DECALPHA 
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
-#elif Platform == I7XEON
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
 	#define EnableDPDLG               ExperimentDisabled
-#elif Platform == XCMAC
-	#define EnableDPDLG               ExperimentDisabled
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else				
-	#define EnableDPDLG               ExperimentDisabled
-#endif					
 
 
 

--- a/src/Flow.cpp
+++ b/src/Flow.cpp
@@ -47,29 +47,6 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 // STL using declarations
 
-#if Platform == DECALPHA 
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
-	using std::transform;
-#elif Platform == I7XEON
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-#elif Platform == XCMAC
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else							
-	using std::transform;
-#endif					
 
 
 //////////////////////////////////////////////////////////////////////

--- a/src/ForceTarget.cpp
+++ b/src/ForceTarget.cpp
@@ -129,21 +129,13 @@ void CForceTarget::RemoveDuplicateBeads()
 {
 	// Sort the beads according to their (unique) id
 
-#if Platform == CRAYJ90
-	sort(m_Beads.begin(), m_Beads.end(), aaBeadIdLess() );
-#else
 	std::sort(m_Beads.begin(), m_Beads.end(), aaBeadIdLess() );
-#endif
 
 	// Now remove adjacent duplicates
 
 	BeadVectorIterator new_end;
 
-#if Platform == CRAYJ90
-	new_end = unique(m_Beads.begin(), m_Beads.end());
-#else
 	new_end = std::unique(m_Beads.begin(), m_Beads.end());
-#endif
 
 	m_Beads.erase(new_end, m_Beads.end());
 

--- a/src/Frap.cpp
+++ b/src/Frap.cpp
@@ -27,41 +27,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 // STL using declarations
 
-#if Platform == DECALPHA 
-#elif Platform == SGICC
-	#define BILAYER_NO_USE_VALARRAY 1
-#elif Platform == CRAYJ90
-	#define BILAYER_NO_USE_VALARRAY 1
-#elif Platform == BORLAND6
-	using std::transform;
-	using std::find;
-	using std::find_if;
 	using std::accumulate;
-#elif Platform == I7XEON
-	using std::transform;
-	using std::accumulate;
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-	using std::accumulate;
-#elif Platform == XCMAC
-	using std::accumulate;
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else							
-	using std::transform;
-	using std::find;
-	using std::find_if;
-	using std::accumulate;
-#endif					
 
 
 //////////////////////////////////////////////////////////////////////

--- a/src/Gyration.cpp
+++ b/src/Gyration.cpp
@@ -26,29 +26,6 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 
 
-#if Platform == DECALPHA 
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
-	using std::transform;
-#elif Platform == I7XEON
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-#elif Platform == XCMAC
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else							
-	using std::transform;
-#endif					
 
 //////////////////////////////////////////////////////////////////////
 // Construction/Destruction

--- a/src/InitialState.cpp
+++ b/src/InitialState.cpp
@@ -36,39 +36,8 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 // STL using declarations
 
-#if Platform == DECALPHA
 	using std::setw;
 	using std::setprecision;
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
-	using std::setw;
-	using std::setprecision;
-#elif Platform == I7XEON
-	using std::setw;
-	using std::setprecision;
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-	using std::setw;
-	using std::setprecision;
-#elif Platform == XCMAC
-	using std::setw;
-	using std::setprecision;
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else
-	using std::setw;
-	using std::setprecision;
-#endif
 
 
 

--- a/src/InitialStateBLMMultiVesicle.cpp
+++ b/src/InitialStateBLMMultiVesicle.cpp
@@ -27,32 +27,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 // STL using declarations
 
-#if Platform == DECALPHA
 	using std::find;
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
-	using std::find;
-#elif Platform == I7XEON
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-	using std::find;
-#elif Platform == XCMAC
-	using std::find;
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else
-	using std::find;
-#endif					
 
 
 //////////////////////////////////////////////////////////////////////

--- a/src/InitialStateBLMVesicle.cpp
+++ b/src/InitialStateBLMVesicle.cpp
@@ -28,32 +28,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 // STL using declarations
 
-#if Platform == DECALPHA
 	using std::find;
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
-	using std::find;
-#elif Platform == I7XEON
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-	using std::find;
-#elif Platform == XCMAC
-	using std::find;
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else
-	using std::find;
-#endif					
 
 
 //////////////////////////////////////////////////////////////////////

--- a/src/InitialStateColumn.cpp
+++ b/src/InitialStateColumn.cpp
@@ -24,33 +24,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 // STL using declarations
 
-#if Platform == DECALPHA
 	using std::find;
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
-	using std::find;
-#elif Platform == I7XEON
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-	using std::find;
-#elif Platform == CW55MAC
-	using std::find;
-#elif Platform == XCMAC
-	using std::find;
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else
-	using std::find;
-#endif					
 
 //////////////////////////////////////////////////////////////////////
 // Global members

--- a/src/InitialStateFibril.cpp
+++ b/src/InitialStateFibril.cpp
@@ -26,32 +26,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 // STL using declarations
 
-#if Platform == DECALPHA
 	using std::find;
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
-	using std::find;
-#elif Platform == I7XEON
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-	using std::find;
-#elif Platform == XCMAC
-	using std::find;
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else
-	using std::find;
-#endif					
 
 //////////////////////////////////////////////////////////////////////
 // Global members

--- a/src/InitialStateFusionLamella.cpp
+++ b/src/InitialStateFusionLamella.cpp
@@ -26,32 +26,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 // STL using declarations
 
-#if Platform == DECALPHA
 	using std::find;
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
-	using std::find;
-#elif Platform == I7XEON
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-	using std::find;
-#elif Platform == XCMAC
-	using std::find;
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else
-	using std::find;
-#endif					
 
 
 //////////////////////////////////////////////////////////////////////

--- a/src/InitialStateFusionPore.cpp
+++ b/src/InitialStateFusionPore.cpp
@@ -26,32 +26,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 // STL using declarations
 
-#if Platform == DECALPHA
 	using std::find;
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
-	using std::find;
-#elif Platform == I7XEON
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-	using std::find;
-#elif Platform == XCMAC
-	using std::find;
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else
-	using std::find;
-#endif					
 
 
 //////////////////////////////////////////////////////////////////////

--- a/src/InitialStatePEP.cpp
+++ b/src/InitialStatePEP.cpp
@@ -28,32 +28,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 // STL using declarations
 
-#if Platform == DECALPHA
 	using std::find;
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
-	using std::find;
-#elif Platform == I7XEON
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-	using std::find;
-#elif Platform == XCMAC
-	using std::find;
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else
-	using std::find;
-#endif					
 
 
 //////////////////////////////////////////////////////////////////////

--- a/src/InitialStateSlice.cpp
+++ b/src/InitialStateSlice.cpp
@@ -24,33 +24,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 // STL using declarations
 
-#if Platform == DECALPHA
 	using std::find;
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
-	using std::find;
-#elif Platform == I7XEON
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-	using std::find;
-#elif Platform == CW55MAC
-	using std::find;
-#elif Platform == XCMAC
-	using std::find;
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else
-	using std::find;
-#endif					
 
 //////////////////////////////////////////////////////////////////////
 // Global members

--- a/src/InitialStateTubularVesicle.cpp
+++ b/src/InitialStateTubularVesicle.cpp
@@ -27,32 +27,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 // STL using declarations
 
-#if Platform == DECALPHA
 	using std::find;
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
-	using std::find;
-#elif Platform == I7XEON
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-	using std::find;
-#elif Platform == XCMAC
-	using std::find;
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else
-	using std::find;
-#endif					
 
 //////////////////////////////////////////////////////////////////////
 // Global members

--- a/src/InitialStateTwoVesicle.cpp
+++ b/src/InitialStateTwoVesicle.cpp
@@ -26,32 +26,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 // STL using declarations
 
-#if Platform == DECALPHA
 	using std::find;
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
-	using std::find;
-#elif Platform == I7XEON
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-	using std::find;
-#elif Platform == XCMAC
-	using std::find;
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else
-	using std::find;
-#endif					
 
 
 //////////////////////////////////////////////////////////////////////

--- a/src/InitialStateVesicle.cpp
+++ b/src/InitialStateVesicle.cpp
@@ -29,32 +29,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 // STL using declarations
 
-#if Platform == DECALPHA
 	using std::find;
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
-	using std::find;
-#elif Platform == I7XEON
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-	using std::find;
-#elif Platform == XCMAC
-	using std::find;
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else
-	using std::find;
-#endif					
 
 //////////////////////////////////////////////////////////////////////
 // Global members

--- a/src/InitialStateVesicleFusion.cpp
+++ b/src/InitialStateVesicleFusion.cpp
@@ -26,32 +26,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 // STL using declarations
 
-#if Platform == DECALPHA
 	using std::find;
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
-	using std::find;
-#elif Platform == I7XEON
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-	using std::find;
-#elif Platform == XCMAC
-	using std::find;
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else
-	using std::find;
-#endif					
 
 
 //////////////////////////////////////////////////////////////////////

--- a/src/InitialStateWormMicelle.cpp
+++ b/src/InitialStateWormMicelle.cpp
@@ -27,32 +27,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 // STL using declarations
 
-#if Platform == DECALPHA
 	using std::find;
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
-	using std::find;
-#elif Platform == I7XEON
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-	using std::find;
-#elif Platform == XCMAC
-	using std::find;
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else
-	using std::find;
-#endif					
 
 //////////////////////////////////////////////////////////////////////
 // Global members

--- a/src/InputData.cpp
+++ b/src/InputData.cpp
@@ -68,47 +68,9 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 // STL using declarations
 
-#if Platform == DECALPHA
-	typedef std::pair<long, CInputData::LoopTarget*>	idPairLongLoopTarget;
-	typedef std::map<long, CInputData::LoopTarget*>::iterator	idLoopIterator;
-#elif Platform == SGICC
-	typedef std::pair<long, CInputData::LoopTarget*>	idPairLongLoopTarget;
-	typedef std::map<long, CInputData::LoopTarget*>::iterator	idLoopIterator;
-#elif Platform == CRAYJ90
-	typedef pair<const long, CInputData::LoopTarget*>	idPairLongLoopTarget;
-	typedef map<long, CInputData::LoopTarget*>::iterator	idLoopIterator;
-#elif Platform == BORLAND6
 	typedef std::pair<long, CInputData::LoopTarget*>	idPairLongLoopTarget;
 	typedef std::map<long, CInputData::LoopTarget*>::iterator	idLoopIterator;
 	using std::find;
-#elif Platform == I7XEON
-	typedef std::pair<long, CInputData::LoopTarget*>	idPairLongLoopTarget;
-	typedef std::map<long, CInputData::LoopTarget*>::iterator	idLoopIterator;
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-	typedef std::pair<long, CInputData::LoopTarget*>	idPairLongLoopTarget;
-	typedef std::map<long, CInputData::LoopTarget*>::iterator	idLoopIterator;
-	using std::find;
-#elif Platform == XCMAC
-	typedef std::pair<long, CInputData::LoopTarget*>	idPairLongLoopTarget;
-	typedef std::map<long, CInputData::LoopTarget*>::iterator	idLoopIterator;
-	using std::find;
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else
-	typedef std::pair<long, CInputData::LoopTarget*>	idPairLongLoopTarget;
-	typedef std::map<long, CInputData::LoopTarget*>::iterator	idLoopIterator;
-	using std::find;
-#endif					
 
 // Valid characters that can appear in bead/polymer names, operators and
 // elements. Note that names must begin with a letter to distinguish them 
@@ -1007,11 +969,7 @@ zString CInputData::CDR(const zString oldString) const
 	startPos = oldString.find(head);
 	startPos+= head.length();
 
-#if Platform == CRAYJ90
-	tail = '(' + tail.remove(0,startPos);
-#else
 	tail = '(' + tail.erase(0,startPos);	// add opening bracket back
-#endif
 
 	if( !IsShapeValid(tail))
 		return "()";
@@ -1019,21 +977,6 @@ zString CInputData::CDR(const zString oldString) const
 // The Modena string class does not have the erase() member function nor an
 // iterator: we have to use remove() to remove the leading white space.
 
-#if Platform == CRAYJ90
-
-	long j = 1;					// We leave the leading ( alone
-	bool bWhiteSpace = true;
-
-	while(bWhiteSpace && j<tail.size())
-	{
-		if(tail[j] == ' ')
-			tail.remove(j,1);
-		else
-			bWhiteSpace = false;
-		j++;
-	}
-
-#else
 
 	zStringIterator iterChar=tail.begin();	// remove leading whitespace
 	iterChar++;
@@ -1042,7 +985,6 @@ zString CInputData::CDR(const zString oldString) const
 		tail.erase(iterChar);
 	}
 
-#endif
 
 	return tail;
 }
@@ -1057,15 +999,10 @@ zString CInputData::RemoveBrackets(zString oldString) const
 		return oldString;
 	else
 	{
-#if Platform == CRAYJ90
-		oldString.remove(0,1);
-		oldString.remove(oldString.size()-1,1);
-#else
 		oldString.erase(oldString.begin());
 		zStringIterator iterLast = oldString.end();
 		iterLast--;
 		oldString.erase(iterLast);
-#endif
 	}
 
 	return oldString;
@@ -1884,17 +1821,6 @@ zString CInputData::RemoveSpaces(zString oldString) const
     if(!oldString.empty())
     {
         
-#if Platform == CRAYJ90
-	long j = 0;
-	bool bWhiteSpace = true;
-
-	while(bWhiteSpace && j<oldString.size())
-	{
-		if(oldString[j] == ' ')
-			oldString.remove(j,1);
-		j++;
-	}
-#else
 	zStringIterator iterFor	 = oldString.begin();
 	zStringIterator iterBack = oldString.end();
 	iterBack--;
@@ -1910,7 +1836,6 @@ zString CInputData::RemoveSpaces(zString oldString) const
 		}
 	}
     
-#endif
         
     }
     
@@ -2787,19 +2712,11 @@ bool CInputData::IsBeadUniqueInPolymer(const zString bead, const zString shape) 
 			// This relies on the find() algorithm returning the first occurrence 
 			// of a sub-string.
 
-#if Platform == CRAYJ90
-			localElement.remove(0, localElement.find(bead)+bead.size());
-#else
 			localElement.erase(0, localElement.find(bead)+bead.size());
-#endif
 
 			while(!nextChar.empty() && validNameChars.find(nextChar) < validNameChars.length())
 			{
-#if Platform == CRAYJ90
-				localElement.remove(0, 1);
-#else
 				localElement.erase(0, 1);
-#endif
 				nextChar.assign(localElement, 0, 1);
 			}
 		}

--- a/src/Interface.cpp
+++ b/src/Interface.cpp
@@ -42,29 +42,6 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 #include "aaStressTensorPoint.h"		// Actual stress tensor components at a point
 
 
-#if Platform == DECALPHA 
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
-	using std::transform;
-#elif Platform == I7XEON
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-#elif Platform == XCMAC
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else							
-	using std::transform;
-#endif					
 
 //////////////////////////////////////////////////////////////////////
 // Construction/Destruction

--- a/src/LamellaBuilder.cpp
+++ b/src/LamellaBuilder.cpp
@@ -33,31 +33,6 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 #include "LogBuilderError.h"	// needed to log errors assembling the initial state
 
 
-#if Platform == DECALPHA 
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
-	using std::random_shuffle;
-#elif Platform == I7XEON
-	using std::random_shuffle;
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-	using std::random_shuffle;
-#elif Platform == XCMAC
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else							
-	using std::random_shuffle;
-#endif					
 
 
 //////////////////////////////////////////////////////////////////////

--- a/src/LogBondStiffnessChanged.cpp
+++ b/src/LogBondStiffnessChanged.cpp
@@ -22,37 +22,8 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 // STL using declarations
 
-#if Platform == DECALPHA 
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
 	using std::setw;
 	using std::setprecision;
-#elif Platform == I7XEON
-	using std::setw;
-	using std::setprecision;
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-	using std::setw;
-	using std::setprecision;
-#elif Platform == XCMAC
-	using std::setw;
-	using std::setprecision;
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else							
-	using std::setw;
-	using std::setprecision;
-#endif					
 
 //////////////////////////////////////////////////////////////////////
 // Global function for serialization

--- a/src/LogBondStrengthChanged.cpp
+++ b/src/LogBondStrengthChanged.cpp
@@ -22,37 +22,8 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 // STL using declarations
 
-#if Platform == DECALPHA 
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
 	using std::setw;
 	using std::setprecision;
-#elif Platform == I7XEON
-	using std::setw;
-	using std::setprecision;
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-	using std::setw;
-	using std::setprecision;
-#elif Platform == XCMAC
-	using std::setw;
-	using std::setprecision;
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else							
-	using std::setw;
-	using std::setprecision;
-#endif					
 
 
 //////////////////////////////////////////////////////////////////////

--- a/src/LogChargeBeadType.cpp
+++ b/src/LogChargeBeadType.cpp
@@ -22,39 +22,8 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 // STL include files
 
-#if Platform == DECALPHA 
 	using std::setw;
 	using std::setprecision;
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
-	using std::setw;
-	using std::setprecision;
-#elif Platform == I7XEON
-	using std::setw;
-	using std::setprecision;
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-	using std::setw;
-	using std::setprecision;
-#elif Platform == XCMAC
-	using std::setw;
-	using std::setprecision;
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else							
-	using std::setw;
-	using std::setprecision;
-#endif					
 
 
 //////////////////////////////////////////////////////////////////////

--- a/src/LogCurrentStateCamera.cpp
+++ b/src/LogCurrentStateCamera.cpp
@@ -22,39 +22,8 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 // STL using declarations
 
-#if Platform == DECALPHA 
 	using std::setw;
 	using std::setprecision;
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
-	using std::setw;
-	using std::setprecision;
-#elif Platform == I7XEON
-	using std::setw;
-	using std::setprecision;
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-	using std::setw;
-	using std::setprecision;
-#elif Platform == XCMAC
-	using std::setw;
-	using std::setprecision;
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else							
-	using std::setw;
-	using std::setprecision;
-#endif
 
 
 //////////////////////////////////////////////////////////////////////

--- a/src/LogCurrentStateLight.cpp
+++ b/src/LogCurrentStateLight.cpp
@@ -21,37 +21,8 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 // STL using declarations
 
-#if Platform == DECALPHA 
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
 	using std::setw;
 	using std::setprecision;
-#elif Platform == I7XEON
-	using std::setw;
-	using std::setprecision;
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-	using std::setw;
-	using std::setprecision;
-#elif Platform == XCMAC
-	using std::setw;
-	using std::setprecision;
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else							
-	using std::setw;
-	using std::setprecision;
-#endif
 
 //////////////////////////////////////////////////////////////////////
 // Global function for serialization

--- a/src/LogDPDBeadConsIntChanged.cpp
+++ b/src/LogDPDBeadConsIntChanged.cpp
@@ -22,37 +22,8 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 // STL using declarations
 
-#if Platform == DECALPHA 
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
 	using std::setw;
 	using std::setprecision;
-#elif Platform == I7XEON
-	using std::setw;
-	using std::setprecision;
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-	using std::setw;
-	using std::setprecision;
-#elif Platform == XCMAC
-	using std::setw;
-	using std::setprecision;
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else							
-	using std::setw;
-	using std::setprecision;
-#endif
 
 //////////////////////////////////////////////////////////////////////
 // Global function for serialization

--- a/src/LogDPDBeadDissIntChanged.cpp
+++ b/src/LogDPDBeadDissIntChanged.cpp
@@ -21,37 +21,8 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 // STL using declarations
 
-#if Platform == DECALPHA 
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
 	using std::setw;
 	using std::setprecision;
-#elif Platform == I7XEON
-	using std::setw;
-	using std::setprecision;
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-	using std::setw;
-	using std::setprecision;
-#elif Platform == XCMAC
-	using std::setw;
-	using std::setprecision;
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else							
-	using std::setw;
-	using std::setprecision;
-#endif
 
 //////////////////////////////////////////////////////////////////////
 // Global function for serialization

--- a/src/LogFreezeBeadsInSlice.cpp
+++ b/src/LogFreezeBeadsInSlice.cpp
@@ -20,37 +20,8 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 // STL using declarations
 
-#if Platform == DECALPHA 
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
 	using std::setw;
 	using std::setprecision;
-#elif Platform == I7XEON
-	using std::setw;
-	using std::setprecision;
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-	using std::setw;
-	using std::setprecision;
-#elif Platform == XCMAC
-	using std::setw;
-	using std::setprecision;
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else							
-	using std::setw;
-	using std::setprecision;
-#endif
 
 //////////////////////////////////////////////////////////////////////
 // Global function for serialization

--- a/src/LogFreezeBeadsInSphericalShell.cpp
+++ b/src/LogFreezeBeadsInSphericalShell.cpp
@@ -21,37 +21,8 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 // STL using declarations
 
-#if Platform == DECALPHA 
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
 	using std::setw;
 	using std::setprecision;
-#elif Platform == I7XEON
-	using std::setw;
-	using std::setprecision;
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-	using std::setw;
-	using std::setprecision;
-#elif Platform == XCMAC
-	using std::setw;
-	using std::setprecision;
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else							
-	using std::setw;
-	using std::setprecision;
-#endif
 
 //////////////////////////////////////////////////////////////////////
 // Global function for serialization

--- a/src/LogMCAcceptanceRate.cpp
+++ b/src/LogMCAcceptanceRate.cpp
@@ -21,37 +21,8 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 // STL using declarations
 
-#if Platform == DECALPHA 
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
 	using std::setw;
 	using std::setprecision;
-#elif Platform == I7XEON
-	using std::setw;
-	using std::setprecision;
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-	using std::setw;
-	using std::setprecision;
-#elif Platform == XCMAC
-	using std::setw;
-	using std::setprecision;
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else							
-	using std::setw;
-	using std::setprecision;
-#endif
 
 //////////////////////////////////////////////////////////////////////
 // Global function for serialization

--- a/src/LogVelDistMessage.cpp
+++ b/src/LogVelDistMessage.cpp
@@ -21,37 +21,8 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 // STL using declarations
 
-#if Platform == DECALPHA 
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
 	using std::setw;
 	using std::setprecision;
-#elif Platform == I7XEON
-	using std::setw;
-	using std::setprecision;
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-	using std::setw;
-	using std::setprecision;
-#elif Platform == XCMAC
-	using std::setw;
-	using std::setprecision;
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else							
-	using std::setw;
-	using std::setprecision;
-#endif
 
 //////////////////////////////////////////////////////////////////////
 // Global function for serialization

--- a/src/LogVesicleBindsWall.cpp
+++ b/src/LogVesicleBindsWall.cpp
@@ -21,37 +21,8 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 // STL using declarations
 
-#if Platform == DECALPHA 
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
 	using std::setw;
 	using std::setprecision;
-#elif Platform == I7XEON
-	using std::setw;
-	using std::setprecision;
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-	using std::setw;
-	using std::setprecision;
-#elif Platform == XCMAC
-	using std::setw;
-	using std::setprecision;
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else							
-	using std::setw;
-	using std::setprecision;
-#endif
 
 //////////////////////////////////////////////////////////////////////
 // Global function for serialization

--- a/src/LogVesicleUnbindsWall.cpp
+++ b/src/LogVesicleUnbindsWall.cpp
@@ -21,37 +21,8 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 // STL using declarations
 
-#if Platform == DECALPHA 
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
 	using std::setw;
 	using std::setprecision;
-#elif Platform == I7XEON
-	using std::setw;
-	using std::setprecision;
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-	using std::setw;
-	using std::setprecision;
-#elif Platform == XCMAC
-	using std::setw;
-	using std::setprecision;
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else							
-	using std::setw;
-	using std::setprecision;
-#endif
 
 //////////////////////////////////////////////////////////////////////
 // Global function for serialization

--- a/src/LogctSetBondStrength.cpp
+++ b/src/LogctSetBondStrength.cpp
@@ -21,37 +21,8 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 // STL using declarations
 
-#if Platform == DECALPHA 
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
 	using std::setw;
 	using std::setprecision;
-#elif Platform == I7XEON
-	using std::setw;
-	using std::setprecision;
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-	using std::setw;
-	using std::setprecision;
-#elif Platform == XCMAC
-	using std::setw;
-	using std::setprecision;
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else							
-	using std::setw;
-	using std::setprecision;
-#endif					
 
 //////////////////////////////////////////////////////////////////////
 // Global function for serialization

--- a/src/Micelle.cpp
+++ b/src/Micelle.cpp
@@ -41,34 +41,6 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 // STL using declarations
 
-#if Platform == DECALPHA 
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
-	using std::transform;
-	using std::slice;
-	using std::gslice;
-#elif Platform == I7XEON
-	using std::transform;
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-#elif Platform == XCMAC
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else							
-	using std::transform;
-	using std::slice;
-	using std::gslice;
-#endif			
 
 
 //////////////////////////////////////////////////////////////////////

--- a/src/Monitor.cpp
+++ b/src/Monitor.cpp
@@ -148,29 +148,6 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 // STL include files
 
-#if Platform == DECALPHA 
-#elif Platform == SGICC
-	#define MICELLE_NO_USE_VALARRAY 1
-#elif Platform == CRAYJ90
-	#define MICELLE_NO_USE_VALARRAY 1
-#elif Platform == BORLAND6
-#elif Platform == I7XEON
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-#elif Platform == XCMAC
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else							
-#endif			
 
 
 //////////////////////////////////////////////////////////////////////
@@ -384,19 +361,11 @@ CMonitor::CMonitor(CSimState* const psState, const ISimBox* const pISimBox) : IS
 
 	m_vAggregates.clear();
 
-#if Platform == CRAYJ90
-
-	copy(m_pSimState->GetAnalysisState().GetAggregates().begin(), 
-		 m_pSimState->GetAnalysisState().GetAggregates().end(), 
-		 back_inserter(m_vAggregates));
-
-#else
 
 	std::copy(m_pSimState->GetAnalysisState().GetAggregates().begin(), 
 			  m_pSimState->GetAnalysisState().GetAggregates().end(), 
 			  std::back_inserter(m_vAggregates));
 
-#endif
 
 	// **********************************************************************
 	// Create the CObservable objects and store pointers to them in containers

--- a/src/Motor.cpp
+++ b/src/Motor.cpp
@@ -47,37 +47,6 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 #include "Builder.h"					// Needed to access pi
 
 
-#if Platform == DECALPHA 
-#elif Platform == SGICC
-	#define MOTOR_NO_USE_VALARRAY 1
-#elif Platform == CRAYJ90
-	#define MOTOR_NO_USE_VALARRAY 1
-#elif Platform == BORLAND6
-	using std::transform;
-	using std::slice;
-	using std::gslice;
-	using std::find_if;
-#elif Platform == I7XEON
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-#elif Platform == XCMAC
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else							
-	using std::transform;
-	using std::slice;
-	using std::gslice;
-	using std::find_if;
-#endif			
 
 
 //////////////////////////////////////////////////////////////////////

--- a/src/Polymer.cpp
+++ b/src/Polymer.cpp
@@ -301,11 +301,7 @@ void CPolymer::ChangeHeadtoWallBead()
 
 	// now remove the old head bead from m_vBeads
 
-#if Platform == CRAYJ90
-	m_vBeads.erase(find(m_vBeads.begin(), m_vBeads.end(), m_pHead));
-#else
 	m_vBeads.erase(std::find(m_vBeads.begin(), m_vBeads.end(), m_pHead));
-#endif
 
 	// The remove() function appears to leave the length of the vector unchanged
 	//	remove(m_vBeads.begin(), m_vBeads.end(), m_pHead);	// remove the old head

--- a/src/PolymerParser.cpp
+++ b/src/PolymerParser.cpp
@@ -255,30 +255,11 @@ zString CPolymerParser::CDR(const zString oldString)
 	startPos = oldString.find(head);
 	startPos+= head.length();
 
-#if Platform == CRAYJ90
-	tail = '(' + tail.remove(0,startPos);
-#else
 	tail = '(' + tail.erase(0,startPos);	// add opening bracket back
-#endif
 
 // The Modena string class does not have the erase() member function nor an
 // iterator: we have to use remove() to remove the leading white space.
 
-#if Platform == CRAYJ90
-
-	long j = 1;					// We leave the leading ( alone
-	bool bWhiteSpace = true;
-
-	while(bWhiteSpace && j<tail.size())
-	{
-		if(tail[j] == ' ')
-			tail.remove(j,1);
-		else
-			bWhiteSpace = false;
-		j++;
-	}
-
-#else
 
 	zStringIterator iterChar=tail.begin();	// remove leading whitespace
 	iterChar++;
@@ -287,7 +268,6 @@ zString CPolymerParser::CDR(const zString oldString)
 		tail.erase(iterChar);
 	}
 
-#endif
 
 	return tail;
 }
@@ -310,15 +290,10 @@ zString CPolymerParser::RemoveOuterBrackets(zString element)
 		return element;
 	else
 	{
-#if Platform == CRAYJ90
-		element.remove(0,1);
-		element.remove(element.size()-1,1);
-#else
 		element.erase(element.begin());
 		zStringIterator iterLast = element.end();
 		iterLast--;
 		element.erase(iterLast);
-#endif
 	}
 
 	return element;

--- a/src/ScalarObservable.cpp
+++ b/src/ScalarObservable.cpp
@@ -28,31 +28,11 @@ zOutStream& operator<<(zOutStream& os, const CScalarObservable& rOb)
 {
 	os << rOb.GetName() << zEndl;
 
-#if Platform == DECALPHA
 	os << std::setw(12) << std::setprecision(8);	// set field width and precision
 	os << rOb.m_MeanData << "  ";
 	os << std::setw(12) << std::setprecision(8);
 	os << rOb.m_SDevData << zEndl;
 	os << zEndl;
-#elif Platform == SGICC
-	os << setw(12) << setprecision(8);	// set field width and precision
-	os << rOb.m_MeanData << "  ";
-	os << setw(12) << setprecision(8);
-	os << rOb.m_SDevData << zEndl;
-	os << zEndl;
-#elif Platform == CRAYJ90
-	os << setw(12) << setprecision(8);	// set field width and precision
-	os << rOb.m_MeanData << "  ";
-	os << setw(12) << setprecision(8);
-	os << rOb.m_SDevData << zEndl;
-	os << zEndl;
-#else
-	os << std::setw(12) << std::setprecision(8);	// set field width and precision
-	os << rOb.m_MeanData << "  ";
-	os << std::setw(12) << std::setprecision(8);
-	os << rOb.m_SDevData << zEndl;
-	os << zEndl;
-#endif
 
 	return os;
 }

--- a/src/ScalarProfileObservable.cpp
+++ b/src/ScalarProfileObservable.cpp
@@ -32,27 +32,10 @@ zOutStream& operator<<(zOutStream& os, const CScalarProfileObservable& rOb)
 	for(long i=0; i<rOb.m_Size; i++)
 	{
 
-#if Platform == DECALPHA
 		os << std::setw(12) << std::setprecision(8);	// set field width and precision
 		os << rOb.m_MeanData.at(i) << "  ";
 		os << std::setw(12) << std::setprecision(8);
 		os << rOb.m_SDevData.at(i) << zEndl;
-#elif Platform == SGICC
-		os << setw(12) << setprecision(8);	// set field width and precision
-		os << rOb.m_MeanData.at(i) << "  ";
-		os << setw(12) << setprecision(8);
-		os << rOb.m_SDevData.at(i) << zEndl;
-#elif Platform == CRAYJ90
-		os << setw(12) << setprecision(8);	// set field width and precision
-		os << rOb.m_MeanData.at(i) << "  ";
-		os << setw(12) << setprecision(8);
-		os << rOb.m_SDevData.at(i) << zEndl;
-#else
-		os << std::setw(12) << std::setprecision(8);	// set field width and precision
-		os << rOb.m_MeanData.at(i) << "  ";
-		os << std::setw(12) << std::setprecision(8);
-		os << rOb.m_SDevData.at(i) << zEndl;
-#endif
 
 	}
 

--- a/src/SimACNFlags.h
+++ b/src/SimACNFlags.h
@@ -24,40 +24,7 @@
 #define SimACNEnabled	1
 #define SimACNDisabled	2
 
-#if Platform   == DECALPHA 
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
-#elif Platform == I7XEON
 	#define EnableShadowSimBox    SimACNEnabled
 	#define EnableACNCommands     SimACNEnabled
 	#define EnableACNProcesses    SimACNEnabled
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-	#define EnableShadowSimBox    SimACNEnabled
-	#define EnableACNCommands     SimACNEnabled
-	#define EnableACNProcesses    SimACNEnabled
-#elif Platform == CW55MAC
-	#define EnableShadowSimBox    SimACNEnabled
-	#define EnableACNCommands     SimACNEnabled
-	#define EnableACNProcesses    SimACNEnabled
-#elif Platform == XCMAC
-	#define EnableShadowSimBox    SimACNEnabled
-	#define EnableACNCommands     SimACNEnabled
-	#define EnableACNProcesses    SimACNEnabled
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else							
-	#define EnableShadowSimBox    SimACNEnabled
-	#define EnableACNCommands     SimACNEnabled
-	#define EnableACNProcesses    SimACNEnabled
-#endif					
 

--- a/src/SimAlgorithmFlags.h
+++ b/src/SimAlgorithmFlags.h
@@ -20,27 +20,6 @@
 //
 // **********************************************************************
 
-#if Platform == DECALPHA 
-	#include <algorithm>
-#elif Platform == SGICC
-	#include <algo.h>
-#elif Platform == CRAYJ90
-	#include <algo.h>
-#elif Platform == BORLAND6
-	#include <algorithm>
-	using std::copy;
-	using std::find;
-	using std::find_if;
-	using std::back_inserter;
-#elif Platform == I7XEON
-	#include <algorithm>
-	using std::copy;
-	using std::find;
-	using std::find_if;
-	using std::back_inserter;
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
 	#include <algorithm>
 	using std::copy;
 	using std::find;
@@ -48,31 +27,4 @@
 	using std::back_inserter;
 	using std::pair;
 	using std::make_pair;
-#elif Platform == XCMAC
-	#include <algorithm>
-	using std::copy;
-	using std::find;
-	using std::find_if;
-	using std::back_inserter;
-	using std::pair;
-	using std::make_pair;
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else							
-	#include <algorithm>
-	using std::copy;
-	using std::find;
-	using std::find_if;
-	using std::back_inserter;
-	using std::pair;
-	using std::make_pair;
-#endif					
 

--- a/src/SimBox.cpp
+++ b/src/SimBox.cpp
@@ -247,48 +247,8 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 #endif
 
 
-#if Platform == DECALPHA 
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
-	using std::cout;
-	using std::remove_if;
-	using std::for_each;
-	using std::mem_fun;
-	using std::mem_fun1;
-	using std::bind2nd;
-#elif Platform == I7XEON
-	using std::cout;
-	using std::remove_if;
-	using std::for_each;
-	using std::mem_fun;
-	using std::mem_fun1;
-	using std::bind2nd;
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
 	using std::cout;
 	using std::mem_fun;
-#elif Platform == XCMAC
-	using std::cout;
-	using std::mem_fun;
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else							
-	using std::cout;
-	using std::remove_if;
-	using std::for_each;
-	using std::mem_fun;
-	using std::bind2nd;
-#endif			
 
 //////////////////////////////////////////////////////////////////////
 // Construction/Destruction
@@ -1105,22 +1065,12 @@ void CSimBox::Evolve()
 	// the Cray STL list<> class does not have an erase() member function we have 
 	// to remove the element differently on that platform.
 
-#if Platform == CRAYJ90
-	TargetIterator nextTarget = 0;
-#endif
 
 	for(ForceTargetIterator iterTarget=m_ActiveForceTargets.begin(); iterTarget!=m_ActiveForceTargets.end();)
 	{
 		if(!(*iterTarget)->AddForce(m_SimTime))
 		{
-#if Platform == CRAYJ90
-			nextTarget = iterTarget;
-			nextTarget++;
-			m_ActiveForceTargets.erase(iterTarget);
-			iterTarget = nextTarget;
-#else
 			iterTarget = m_ActiveForceTargets.erase(iterTarget);
-#endif
 		}
 		else
 			iterTarget++;
@@ -3968,9 +3918,6 @@ void CSimBox::UnchargeBeadType(const xxCommand *const pCommand)
 		// in a list, we can delete a contiguous range of elements without invalidating
 		// the remainder of the container.
 
-#if Platform == CRAYJ90
-		ChargedBeadListIterator nextBead = 0;
-#endif
 
 		// Note the absence of the increment step because we use erase()  
 		// to remove beads of the specified type, and increment it manually when
@@ -3982,14 +3929,7 @@ void CSimBox::UnchargeBeadType(const xxCommand *const pCommand)
 			{
 				delete *iterBead;
 
-#if Platform == CRAYJ90
-				nextBead = iterBead;
-				nextBead++;
-				m_lAllChargedBeads.erase(iterBead);
-				iterBead = nextBead;
-#else
 				iterBead = m_lAllChargedBeads.erase(iterBead);
-#endif
 			}
 			else
 				iterBead++;

--- a/src/SimCommandFlags.h
+++ b/src/SimCommandFlags.h
@@ -31,11 +31,6 @@
 #define SimCommandEnabled	1
 #define SimCommandDisabled	2
 
-#if Platform   == DECALPHA 
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
-#elif Platform == I7XEON
 	#define EnableACNCommand               SimCommandEnabled
 	#define EnableCommandGroups            SimCommandEnabled
 	#define EnableConstraintCommand        SimCommandEnabled
@@ -43,48 +38,4 @@
 	#define EnableProcessCommand           SimCommandEnabled
 	#define EnableTargetCommand            SimCommandEnabled
 	#define EnableDirectImplCommand        SimCommandDisabled
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-	#define EnableACNCommand               SimCommandEnabled
-	#define EnableCommandGroups            SimCommandEnabled
-	#define EnableConstraintCommand        SimCommandEnabled
-	#define EnableMonitorCommand           SimCommandEnabled
-	#define EnableProcessCommand           SimCommandEnabled
-	#define EnableTargetCommand            SimCommandEnabled
-	#define EnableDirectImplCommand        SimCommandEnabled
-#elif Platform == CW55MAC
-	#define EnableACNCommand               SimCommandEnabled
-	#define EnableCommandGroups            SimCommandEnabled
-	#define EnableConstraintCommand        SimCommandEnabled
-	#define EnableMonitorCommand           SimCommandEnabled
-	#define EnableProcessCommand           SimCommandEnabled
-	#define EnableTargetCommand            SimCommandEnabled
-	#define EnableDirectImplCommand        SimCommandDisabled
-#elif Platform == XCMAC
-	#define EnableACNCommand               SimCommandEnabled
-	#define EnableCommandGroups            SimCommandEnabled
-	#define EnableConstraintCommand        SimCommandEnabled
-	#define EnableMonitorCommand           SimCommandEnabled
-	#define EnableProcessCommand           SimCommandEnabled
-	#define EnableTargetCommand            SimCommandEnabled
-	#define EnableDirectImplCommand        SimCommandDisabled
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else							
-	#define EnableACNCommand               SimCommandEnabled
-	#define EnableCommandGroups            SimCommandEnabled
-	#define EnableConstraintCommand        SimCommandEnabled
-	#define EnableMonitorCommand           SimCommandEnabled
-	#define EnableProcessCommand           SimCommandEnabled
-	#define EnableTargetCommand            SimCommandEnabled
-	#define EnableDirectImplCommand        SimCommandDisabled
-#endif					
 

--- a/src/SimFunctionalFlags.h
+++ b/src/SimFunctionalFlags.h
@@ -13,30 +13,5 @@
 //
 // **********************************************************************
 
-#if Platform == DECALPHA 
 	#include <functional>
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
-	#include <functional>
-#elif Platform == I7XEON
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-	#include <functional>
-#elif Platform == XCMAC
-	#include <functional>
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else							
-	#include <functional>
-#endif					
 

--- a/src/SimIteratorFlags.h
+++ b/src/SimIteratorFlags.h
@@ -13,30 +13,5 @@
 //
 // **********************************************************************
 
-#if Platform == DECALPHA 
 	#include <iterator>
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
-	#include <iterator>
-#elif Platform == I7XEON
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-	#include <iterator>
-#elif Platform == XCMAC
-	#include <iterator>
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else							
-	#include <iterator>
-#endif					
 

--- a/src/SimMPSFlags.h
+++ b/src/SimMPSFlags.h
@@ -31,25 +31,6 @@
 #define SimMPSEnabled	1
 #define SimMPSDisabled	2
 
-#if Platform   == DECALPHA 
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
-#elif Platform == I7XEON
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-	#define EnableParallelACN           SimMPSDisabled
-	#define EnableParallelAggregates    SimMPSDisabled
-	#define EnableParallelCommands      SimMPSEnabled
-	#define EnableParallelEvents        SimMPSDisabled
-	#define EnableParallelExperiment    SimMPSEnabled
-	#define EnableParallelMonitor       SimMPSEnabled
-	#define EnableParallelProcesses     SimMPSDisabled
-	#define EnableParallelRestart       SimMPSDisabled
-	#define EnableParallelSimBox        SimMPSEnabled
-	#define EnableParallelTargets       SimMPSDisabled
-#elif Platform == XCMAC
 	#define EnableParallelACN           SimMPSDisabled
 	#define EnableParallelAggregates    SimMPSDisabled
 	#define EnableParallelCommands      SimMPSDisabled
@@ -60,26 +41,4 @@
 	#define EnableParallelRestart       SimMPSDisabled
 	#define EnableParallelSimBox        SimMPSDisabled
 	#define EnableParallelTargets       SimMPSDisabled
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else							
-	#define EnableParallelACN           SimMPSDisabled
-	#define EnableParallelAggregates    SimMPSDisabled
-	#define EnableParallelCommands      SimMPSDisabled
-	#define EnableParallelEvents        SimMPSDisabled
-	#define EnableParallelExperiment    SimMPSDisabled
-	#define EnableParallelMonitor       SimMPSDisabled
-	#define EnableParallelProcesses     SimMPSDisabled
-	#define EnableParallelRestart       SimMPSDisabled
-	#define EnableParallelSimBox        SimMPSDisabled
-	#define EnableParallelTargets       SimMPSDisabled
-#endif					
 

--- a/src/SimMathFlags.h
+++ b/src/SimMathFlags.h
@@ -15,32 +15,4 @@
 //
 // **********************************************************************
 
-#if Platform == DECALPHA 
 	#include <math.h>
-#elif Platform == SGICC
-	#include <math.h>
-#elif Platform == CRAYJ90
-	#include <math.h>
-#elif Platform == BORLAND6
-	#include <math>
-#elif Platform == I7XEON
-	#include <cmath>
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-	#include <math.h>
-#elif Platform == XCMAC
-	#include <math.h>
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else							
-	#include <cmath>			
-#endif					

--- a/src/SimMiscellaneousFlags.h
+++ b/src/SimMiscellaneousFlags.h
@@ -16,32 +16,6 @@
 #define SimMiscEnabled	1
 #define SimMiscDisabled	2
 
-#if Platform   == DECALPHA 
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
-#elif Platform == I7XEON
-	#define EnableMiscClasses               SimMiscEnabled
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-	#define EnableMiscClasses               SimMiscEnabled
-#elif Platform == CW55MAC
-	#define EnableMiscClasses               SimMiscEnabled
-#elif Platform == XCMAC
 	#define EnableMiscClasses               SimMiscEnabled
 	#define EnableStressTensorSphere        SimMiscDisabled
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else							
-	#define EnableMiscClasses               SimMiscEnabled
-
-#endif					
 

--- a/src/SimNumericFlags.h
+++ b/src/SimNumericFlags.h
@@ -14,34 +14,6 @@
 //
 // **********************************************************************
 
-#if Platform == DECALPHA 
-	#include <numeric>
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
-	#include <numeric>
-#elif Platform == I7XEON
-	#include <numeric>
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
 	#include <numeric>
     using std::accumulate;
-#elif Platform == XCMAC
-	#include <numeric>
-    using std::accumulate;
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else							
-	#include <numeric>
-    using std::accumulate;
-#endif					
 

--- a/src/SimProcessFlags.h
+++ b/src/SimProcessFlags.h
@@ -40,46 +40,6 @@
 #define SimProcessEnabled	1
 #define SimProcessDisabled	2
 
-#if Platform   == DECALPHA 
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
-#elif Platform == I7XEON
-	#define EnableModifiableProcess        SimProcessEnabled
-	#define EnableCommandDocumentProcess   SimProcessEnabled
-	#define EnableCommandQueueProcess      SimProcessEnabled
-	#define EnableLightFieldProcess        SimProcessDisabled
-	#define EnableProbeFieldProcess        SimProcessDisabled
-	#define EnableBilayerProcess           SimProcessDisabled
-	#define EnableBilayerFusionProcess     SimProcessDisabled
-	#define EnableBilayerRaftProcess       SimProcessDisabled
-	#define EnableBilayerRuptSurfProcess   SimProcessDisabled
-	#define EnableBilayerRuptTensProcess   SimProcessDisabled
-	#define EnableBLMVesicleFusionProcess  SimProcessEnabled
-	#define EnableVesicleFusionProcess     SimProcessDisabled
-	#define EnableVesicleShearProcess      SimProcessDisabled
-	#define EnablefActinProcess            SimProcessEnabled
-	#define EnableForminProcess            SimProcessEnabled
-	#define EnableAnalysisEvents           SimProcessEnabled
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-	#define EnableModifiableProcess        SimProcessEnabled
-	#define EnableCommandDocumentProcess   SimProcessEnabled
-	#define EnableCommandQueueProcess      SimProcessEnabled
-	#define EnableLightFieldProcess        SimProcessDisabled
-	#define EnableProbeFieldProcess        SimProcessDisabled
-	#define EnableBilayerProcess           SimProcessDisabled
-	#define EnableBilayerFusionProcess     SimProcessDisabled
-	#define EnableBilayerRaftProcess       SimProcessDisabled
-	#define EnableBilayerRuptSurfProcess   SimProcessDisabled
-	#define EnableBilayerRuptTensProcess   SimProcessDisabled
-	#define EnableBLMVesicleFusionProcess  SimProcessEnabled
-	#define EnableVesicleFusionProcess     SimProcessDisabled
-	#define EnableVesicleShearProcess      SimProcessDisabled
-	#define EnablefActinProcess            SimProcessEnabled
-	#define EnableForminProcess            SimProcessEnabled
-	#define EnableAnalysisEvents           SimProcessEnabled
-#elif Platform == CW55MAC
 	#define EnableModifiableProcess        SimProcessEnabled
 	#define EnableCommandDocumentProcess   SimProcessEnabled
 	#define EnableCommandQueueProcess      SimProcessEnabled
@@ -96,51 +56,4 @@
 	#define EnablefActinProcess            SimProcessEnabled
 	#define EnableForminProcess            SimProcessEnabled
 	#define EnableAnalysisEvents           SimProcessDisabled
-#elif Platform == XCMAC
-	#define EnableModifiableProcess        SimProcessEnabled
-	#define EnableCommandDocumentProcess   SimProcessEnabled
-	#define EnableCommandQueueProcess      SimProcessEnabled
-	#define EnableLightFieldProcess        SimProcessDisabled
-	#define EnableProbeFieldProcess        SimProcessDisabled
-	#define EnableBilayerProcess           SimProcessDisabled
-	#define EnableBilayerFusionProcess     SimProcessDisabled
-	#define EnableBilayerRaftProcess       SimProcessDisabled
-	#define EnableBilayerRuptSurfProcess   SimProcessDisabled
-	#define EnableBilayerRuptTensProcess   SimProcessDisabled
-	#define EnableBLMVesicleFusionProcess  SimProcessEnabled
-	#define EnableVesicleFusionProcess     SimProcessDisabled
-	#define EnableVesicleShearProcess      SimProcessDisabled
-	#define EnablefActinProcess            SimProcessEnabled
-	#define EnableForminProcess            SimProcessEnabled
-	#define EnableAnalysisEvents           SimProcessDisabled
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else							
-	#define EnableModifiableProcess        SimProcessEnabled
-	#define EnableCommandDocumentProcess   SimProcessEnabled
-	#define EnableCommandQueueProcess      SimProcessEnabled
-	#define EnableLightFieldProcess        SimProcessDisabled
-	#define EnableProbeFieldProcess        SimProcessDisabled
-	#define EnableBilayerProcess           SimProcessDisabled
-	#define EnableBilayerFusionProcess     SimProcessDisabled
-	#define EnableBilayerRaftProcess       SimProcessDisabled
-	#define EnableBilayerRuptSurfProcess   SimProcessDisabled
-	#define EnableBilayerRuptTensProcess   SimProcessDisabled
-	#define EnableBLMVesicleFusionProcess  SimProcessEnabled
-	#define EnableVesicleFusionProcess     SimProcessDisabled
-	#define EnableVesicleShearProcess      SimProcessDisabled
-	#define EnablefActinProcess            SimProcessEnabled
-	#define EnableForminProcess            SimProcessEnabled
-
-	#define EnableAnalysisEvents           SimProcessEnabled
-
-#endif					
 

--- a/src/SimStdlibFlags.h
+++ b/src/SimStdlibFlags.h
@@ -13,32 +13,5 @@
 //
 // **********************************************************************
 
-#if Platform == DECALPHA 
 	#include <stdlib.h>
-#elif Platform == SGICC
-	#include <stdlib.h>
-#elif Platform == CRAYJ90
-	#include <stdlib.h>
-#elif Platform == BORLAND6
-	#include <stdlib>
-#elif Platform == I7XEON
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-	#include <stdlib.h>
-#elif Platform == XCMAC
-	#include <stdlib.h>
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else							
-	#include <cstdlib>
-#endif					
 

--- a/src/SimXMLFlags.h
+++ b/src/SimXMLFlags.h
@@ -33,40 +33,9 @@
 #define SimXMLEnabled	1
 #define SimXMLDisabled	2
 
-#if Platform   == DECALPHA 
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
-#elif Platform == I7XEON
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
 	#define EnableXMLProtocol               SimXMLDisabled
 	#define EnableXMLProcesses              SimXMLDisabled
 	#define EnableXMLDecorators             SimXMLDisabled
 	#define EnableXMLCommands               SimXMLDisabled
 	#define EnableXMLParallelMessagess      SimXMLDisabled
-#elif Platform == XCMAC
-	#define EnableXMLProtocol               SimXMLDisabled
-	#define EnableXMLProcesses              SimXMLDisabled
-	#define EnableXMLDecorators             SimXMLDisabled
-	#define EnableXMLCommands               SimXMLDisabled
-	#define EnableXMLParallelMessagess      SimXMLDisabled
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else							
-	#define EnableXMLProtocol               SimXMLDisabled
-	#define EnableXMLProcesses              SimXMLDisabled
-	#define EnableXMLDecorators             SimXMLDisabled
-	#define EnableXMLCommands               SimXMLDisabled
-	#define EnableXMLParallelMessagess      SimXMLDisabled
-#endif					
 

--- a/src/Slice.cpp
+++ b/src/Slice.cpp
@@ -28,32 +28,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 // STL using declarations
 
-#if Platform == DECALPHA 
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
 	using std::remove_if;
-#elif Platform == I7XEON
-	using std::remove_if;
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-	using std::remove_if;
-#elif Platform == XCMAC
-	using std::remove_if;
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else							
-	using std::remove_if;
-#endif			
 
 
 //////////////////////////////////////////////////////////////////////

--- a/src/TensorObservable.cpp
+++ b/src/TensorObservable.cpp
@@ -32,7 +32,6 @@ zOutStream& operator<<(zOutStream& os, const CTensorObservable& rOb)
 	for(short int j=0; j<3; j++)
 	{
 
-#if Platform == DECALPHA
 		os << std::setw(12) << std::setprecision(6) << zLeft;	// set field width and precision
 		os << rOb.m_MeanData[3*j]   << " ";
 		os << std::setw(12) << std::setprecision(6) << zLeft;
@@ -45,46 +44,6 @@ zOutStream& operator<<(zOutStream& os, const CTensorObservable& rOb)
 		os << rOb.m_SDevData[3*j+1] << " ";
 		os << std::setw(12) << std::setprecision(6) << zLeft;
 		os << rOb.m_SDevData[3*j+2] << zEndl;
-#elif Platform == SGICC
-		os << setw(12) << setprecision(6) << zLeft;	// set field width and precision
-		os << rOb.m_MeanData[3*j]   << " ";
-		os << setw(12) << setprecision(6) << zLeft;
-		os << rOb.m_MeanData[3*j+1] << " ";
-		os << setw(12) << setprecision(6) << zLeft;
-		os << rOb.m_MeanData[3*j+2] << "  ";
-		os << setw(12) << setprecision(6) << zLeft;
-		os << rOb.m_SDevData[3*j] << " ";
-		os << setw(12) << setprecision(6) << zLeft;
-		os << rOb.m_SDevData[3*j+1] << " ";
-		os << setw(12) << setprecision(6) << zLeft;
-		os << rOb.m_SDevData[3*j+2] << zEndl;
-#elif Platform == CRAYJ90
-		os << setw(12) << setprecision(6) << zLeft;	// set field width and precision
-		os << rOb.m_MeanData[3*j]   << " ";
-		os << setw(12) << setprecision(6) << zLeft;
-		os << rOb.m_MeanData[3*j+1] << " ";
-		os << setw(12) << setprecision(6) << zLeft;
-		os << rOb.m_MeanData[3*j+2] << "  ";
-		os << setw(12) << setprecision(6) << zLeft;
-		os << rOb.m_SDevData[3*j] << " ";
-		os << setw(12) << setprecision(6) << zLeft;
-		os << rOb.m_SDevData[3*j+1] << " ";
-		os << setw(12) << setprecision(6) << zLeft;
-		os << rOb.m_SDevData[3*j+2] << zEndl;
-#else
-		os << std::setw(12) << std::setprecision(6) << zLeft;	// set field width and precision
-		os << rOb.m_MeanData[3*j]   << " ";
-		os << std::setw(12) << std::setprecision(6) << zLeft;
-		os << rOb.m_MeanData[3*j+1] << " ";
-		os << std::setw(12) << std::setprecision(6) << zLeft;
-		os << rOb.m_MeanData[3*j+2] << "  ";
-		os << std::setw(12) << std::setprecision(6) << zLeft;
-		os << rOb.m_SDevData[3*j] << " ";
-		os << std::setw(12) << std::setprecision(6) << zLeft;
-		os << rOb.m_SDevData[3*j+1] << " ";
-		os << std::setw(12) << std::setprecision(6) << zLeft;
-		os << rOb.m_SDevData[3*j+2] << zEndl;
-#endif
 
 	}
 

--- a/src/TimeSeriesData.cpp
+++ b/src/TimeSeriesData.cpp
@@ -20,37 +20,8 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 #include "SimXMLFlags.h"
 #include "TimeSeriesData.h"
 
-#if Platform == DECALPHA 
 	using std::setw;
 	using std::setprecision;
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
-#elif Platform == I7XEON
-	using std::setw;
-	using std::setprecision;
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-	using std::setw;
-	using std::setprecision;
-#elif Platform == XCMAC
-	using std::setw;
-	using std::setprecision;
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else							
-	using std::setw;
-	using std::setprecision;
-#endif					
 
 
 

--- a/src/VectorObservable.cpp
+++ b/src/VectorObservable.cpp
@@ -26,7 +26,6 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 zOutStream& operator<<(zOutStream& os, const CVectorObservable& rOb)
 {
-#if Platform == DECALPHA
 	os << rOb.GetName() << zEndl;
 	for(short int j=0; j<3; j++)
 	{
@@ -40,50 +39,6 @@ zOutStream& operator<<(zOutStream& os, const CVectorObservable& rOb)
 	os << std::setw(14) << std::setprecision(8) << zLeft;
 	os << rOb.m_SDevMag << zEndl;
 	os << zEndl;
-
-#elif Platform == SGICC
-	os << rOb.GetName() << zEndl;
-	for(short int j=0; j<3; j++)
-	{
-		os << setw(14) << setprecision(8) << zLeft;
-		os << rOb.m_MeanData[j] << " ";
-		os << setw(14) << setprecision(8) << zLeft;
-		os << rOb.m_SDevData[j] << zEndl;
-	}
-	os << setw(14) << setprecision(8) << zLeft;
-	os << rOb.m_MeanMag << " ";
-	os << setw(14) << setprecision(8) << zLeft;
-	os << rOb.m_SDevMag << zEndl;
-	os << zEndl;
-#elif Platform == CRAYJ90
-	os << rOb.GetName() << zEndl;
-	for(short int j=0; j<3; j++)
-	{
-		os << setw(14) << setprecision(8) << zLeft;
-		os << rOb.m_MeanData[j] << " ";
-		os << setw(14) << setprecision(8) << zLeft;
-		os << rOb.m_SDevData[j] << zEndl;
-	}
-	os << setw(14) << setprecision(8) << zLeft;
-	os << rOb.m_MeanMag << " ";
-	os << setw(14) << setprecision(8) << zLeft;
-	os << rOb.m_SDevMag << zEndl;
-	os << zEndl;
-#else
-	os << rOb.GetName() << zEndl;
-	for(short int j=0; j<3; j++)
-	{
-		os << std::setw(14) << std::setprecision(8) << zLeft;
-		os << rOb.m_MeanData[j] << " ";
-		os << std::setw(14) << std::setprecision(8) << zLeft;
-		os << rOb.m_SDevData[j] << zEndl;
-	}
-	os << std::setw(14) << std::setprecision(8) << zLeft;
-	os << rOb.m_MeanMag << " ";
-	os << std::setw(14) << std::setprecision(8) << zLeft;
-	os << rOb.m_SDevMag << zEndl;
-	os << zEndl;
-#endif
 
 	return os;
 }

--- a/src/VectorProfileObservable.cpp
+++ b/src/VectorProfileObservable.cpp
@@ -32,7 +32,6 @@ zOutStream& operator<<(zOutStream& os, const CVectorProfileObservable& rOb)
 	for(long i=0; i<rOb.m_Size; i++)
 	{
 
-#if Platform == DECALPHA
 		os << std::setw(8) << std::setprecision(4);	// set field width and precision
 		os << rOb.m_MeanX.at(i) << "  ";
 		os << std::setw(8) << std::setprecision(4);	
@@ -50,61 +49,6 @@ zOutStream& operator<<(zOutStream& os, const CVectorProfileObservable& rOb)
 		os << rOb.m_SDevZ.at(i) << "  ";
 		os << std::setw(8) << std::setprecision(4);
 		os << rOb.m_SDevMag.at(i) << zEndl;
-#elif Platform == SGICC
-		os << setw(8) << setprecision(4);	// set field width and precision
-		os << rOb.m_MeanX.at(i) << "  ";
-		os << setw(8) << setprecision(4);	
-		os << rOb.m_MeanY.at(i) << "  ";
-		os << setw(8) << setprecision(4);	
-		os << rOb.m_MeanZ.at(i) << "  ";
-		os << setw(8) << setprecision(4);	
-		os << rOb.m_MeanMag.at(i)   << "  ";
-
-		os << setw(8) << setprecision(4);
-		os << rOb.m_SDevX.at(i) << "  ";
-		os << setw(8) << setprecision(4);
-		os << rOb.m_SDevY.at(i) << "  ";
-		os << setw(8) << setprecision(4);
-		os << rOb.m_SDevZ.at(i) << "  ";
-		os << setw(8) << setprecision(4);
-		os << rOb.m_SDevMag.at(i) << zEndl;
-#elif Platform == CRAYJ90
-		os << setw(8) << setprecision(4);	// set field width and precision
-		os << rOb.m_MeanX.at(i) << "  ";
-		os << setw(8) << setprecision(4);	
-		os << rOb.m_MeanY.at(i) << "  ";
-		os << setw(8) << setprecision(4);	
-		os << rOb.m_MeanZ.at(i) << "  ";
-		os << setw(8) << setprecision(4);	
-		os << rOb.m_MeanMag.at(i)   << "  ";
-
-		os << setw(8) << setprecision(4);
-		os << rOb.m_SDevX.at(i) << "  ";
-		os << setw(8) << setprecision(4);
-		os << rOb.m_SDevY.at(i) << "  ";
-		os << setw(8) << setprecision(4);
-		os << rOb.m_SDevZ.at(i) << "  ";
-		os << setw(8) << setprecision(4);
-		os << rOb.m_SDevMag.at(i) << zEndl;
-#else
-		os << std::setw(8) << std::setprecision(4);	// set field width and precision
-		os << rOb.m_MeanX.at(i) << "  ";
-		os << std::setw(8) << std::setprecision(4);	
-		os << rOb.m_MeanY.at(i) << "  ";
-		os << std::setw(8) << std::setprecision(4);	
-		os << rOb.m_MeanZ.at(i) << "  ";
-		os << std::setw(8) << std::setprecision(4);	
-		os << rOb.m_MeanMag.at(i)   << "  ";
-
-		os << std::setw(8) << std::setprecision(4);
-		os << rOb.m_SDevX.at(i) << "  ";
-		os << std::setw(8) << std::setprecision(4);
-		os << rOb.m_SDevY.at(i) << "  ";
-		os << std::setw(8) << std::setprecision(4);
-		os << rOb.m_SDevZ.at(i) << "  ";
-		os << std::setw(8) << std::setprecision(4);
-		os << rOb.m_SDevMag.at(i) << zEndl;
-#endif
 
 	}
 

--- a/src/Vesicle.cpp
+++ b/src/Vesicle.cpp
@@ -45,37 +45,6 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 // STL using declarations
 
-#if Platform == DECALPHA 
-#elif Platform == SGICC
-	#define BILAYER_NO_USE_VALARRAY 1
-#elif Platform == CRAYJ90
-	#define BILAYER_NO_USE_VALARRAY 1
-#elif Platform == BORLAND6
-	using std::transform;
-	using std::slice;
-	using std::gslice;
-#elif Platform == I7XEON
-	#define BILAYER_NO_USE_VALARRAY 1
-	using std::transform;
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-#elif Platform == XCMAC
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else							
-	using std::transform;
-	using std::slice;
-	using std::gslice;
-#endif					
 
 //////////////////////////////////////////////////////////////////////
 // Construction/Destruction

--- a/src/aaRegionToType.h
+++ b/src/aaRegionToType.h
@@ -33,37 +33,8 @@
 
 // STL using declarations
 
-#if Platform == DECALPHA
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
 	using std::count_if;
 	using std::unary_function;
-#elif Platform == I7XEON
-	using std::count_if;
-	using std::unary_function;
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-	using std::count_if;
-	using std::unary_function;
-#elif Platform == XCMAC
-	using std::count_if;
-	using std::unary_function;
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else
-	using std::count_if;
-	using std::unary_function;
-#endif					
 
 // **********************************************************************
 // Definitions of function objects used in analysing aggregates. 

--- a/src/aeActiveBond1dProfile.cpp
+++ b/src/aeActiveBond1dProfile.cpp
@@ -24,52 +24,11 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 #include "aaRegionToType.h"
 #include "LogTextMessage.h"
 
-#if Platform == DECALPHA 
-#elif Platform == SGICC
-	#define BILAYER_NO_USE_VALARRAY 1
-#elif Platform == CRAYJ90
-	#define BILAYER_NO_USE_VALARRAY 1
-#elif Platform == BORLAND6
 	using std::transform;
 	using std::slice;
 	using std::gslice;
 	using std::find;
 	using std::find_if;
-#elif Platform == I7XEON
-	using std::transform;
-	using std::slice;
-	using std::gslice;
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-	using std::transform;
-	using std::slice;
-	using std::gslice;
-	using std::find;
-	using std::find_if;
-#elif Platform == XCMAC
-	using std::transform;
-	using std::slice;
-	using std::gslice;
-	using std::find;
-	using std::find_if;
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else							
-	using std::transform;
-	using std::slice;
-	using std::gslice;
-	using std::find;
-	using std::find_if;
-#endif					
 
 
 //////////////////////////////////////////////////////////////////////

--- a/src/aeCNTCell.cpp
+++ b/src/aeCNTCell.cpp
@@ -24,34 +24,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 // STL using declarations
 
-#if Platform == DECALPHA 
 	using std::random_shuffle;
-#elif Platform == SGICC
-	using std::random_shuffle;
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
-	using std::random_shuffle;
-#elif Platform == I7XEON
-	using std::random_shuffle;
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-	using std::random_shuffle;
-#elif Platform == XCMAC
-	using std::random_shuffle;
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else							
-	using std::random_shuffle;
-#endif					
 
 
 //////////////////////////////////////////////////////////////////////

--- a/src/ccAddBeadsInCell.cpp
+++ b/src/ccAddBeadsInCell.cpp
@@ -266,13 +266,8 @@ bool ccAddBeadsInCell::IsDataValid(const CInputData &riData) const
 
 					const StringSequence targetBeads = pTarget->GetNames();
 
-#if Platform == CRAYJ90
-					if(find(targetBeads.begin(), targetBeads.end(), name) != targetBeads.end())
-						bDistinctNames = false;
-#else
 					if(std::find(targetBeads.begin(), targetBeads.end(), name) != targetBeads.end())
 						bDistinctNames = false;
-#endif
 				}
 				if(!bDistinctNames)
 					return ErrorTrace("Error: Beads overlap with previous Select/Add command");;

--- a/src/ccAddBeadsInRow.cpp
+++ b/src/ccAddBeadsInRow.cpp
@@ -279,13 +279,8 @@ bool ccAddBeadsInRow::IsDataValid(const CInputData &riData) const
 
 					const StringSequence targetBeads = pTarget->GetNames();
 
-#if Platform == CRAYJ90
-					if(find(targetBeads.begin(), targetBeads.end(), name) != targetBeads.end())
-						bDistinctNames = false;
-#else
 					if(std::find(targetBeads.begin(), targetBeads.end(), name) != targetBeads.end())
 						bDistinctNames = false;
-#endif
 				}
 				if(!bDistinctNames)
 					return ErrorTrace("Error: Beads overlap with previous Select/Add command");;

--- a/src/ccAddBeadsInSlice.cpp
+++ b/src/ccAddBeadsInSlice.cpp
@@ -266,13 +266,8 @@ bool ccAddBeadsInSlice::IsDataValid(const CInputData &riData) const
 
 					const StringSequence targetBeads = pTarget->GetNames();
 
-#if Platform == CRAYJ90
-					if(find(targetBeads.begin(), targetBeads.end(), name) != targetBeads.end())
-						bDistinctNames = false;
-#else
 					if(std::find(targetBeads.begin(), targetBeads.end(), name) != targetBeads.end())
 						bDistinctNames = false;
-#endif
 				}
 				if(!bDistinctNames)
 					return ErrorTrace("Error: Beads overlap with previous Select/Add command");;

--- a/src/ccSelection.cpp
+++ b/src/ccSelection.cpp
@@ -23,32 +23,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 // STL using declarations
 
-#if Platform == DECALPHA
 	using std::find;
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
-	using std::find;
-#elif Platform == I7XEON
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-	using std::find;
-#elif Platform == XCMAC
-	using std::find;
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else
-	using std::find;
-#endif					
 
 //////////////////////////////////////////////////////////////////////
 // Global functions

--- a/src/ccUnchargeBeadByTypeImpl.cpp
+++ b/src/ccUnchargeBeadByTypeImpl.cpp
@@ -75,9 +75,6 @@ void ccUnchargeBeadByTypeImpl::UnchargeBeadByType(const xxCommand* const pComman
 		// in a list, we can delete a contiguous range of elements without invalidating
 		// the remainder of the container.
 
-#if Platform == CRAYJ90
-		ChargedBeadListIterator nextBead = 0;
-#endif
 
 		// Note the absence of the increment step because we use erase()  
 		// to remove beads of the specified type, and increment it manually when
@@ -89,14 +86,7 @@ void ccUnchargeBeadByTypeImpl::UnchargeBeadByType(const xxCommand* const pComman
 			{
 				delete *iterBead;
 
-#if Platform == CRAYJ90
-				nextBead = iterBead;
-				nextBead++;
-				pSimBox->m_lAllChargedBeads.erase(iterBead);
-				iterBead = nextBead;
-#else
 				iterBead = pSimBox->m_lAllChargedBeads.erase(iterBead);
-#endif
 			}
 			else
 				iterBead++;

--- a/src/ctExtractBeadTypesIntoCompositeTargetImpl.cpp
+++ b/src/ctExtractBeadTypesIntoCompositeTargetImpl.cpp
@@ -30,33 +30,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 #include "LogTextMessage.h"
 
 
-#if Platform == DECALPHA 
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
 	using std::sort;
-#elif Platform == I7XEON
-	using std::sort;
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-	using std::sort;
-#elif Platform == XCMAC
-	using std::sort;
-#elif Platform == NEWPLATFORM1
-	using std::sort;
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else							
-	using std::sort;
-#endif					
 
 
 //////////////////////////////////////////////////////////////////////

--- a/src/ctExtractBeadTypesIntoTargetsImpl.cpp
+++ b/src/ctExtractBeadTypesIntoTargetsImpl.cpp
@@ -30,33 +30,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 #include "LogTextMessage.h"
 
 
-#if Platform == DECALPHA 
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
 	using std::sort;
-#elif Platform == I7XEON
-	using std::sort;
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-	using std::sort;
-#elif Platform == XCMAC
-	using std::sort;
-#elif Platform == NEWPLATFORM1
-	using std::sort;
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else							
-	using std::sort;
-#endif					
 
 
 //////////////////////////////////////////////////////////////////////

--- a/src/evLamellaBilayerDomain.cpp
+++ b/src/evLamellaBilayerDomain.cpp
@@ -29,29 +29,6 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 #include "CompositeBilayer.h"
 
 
-#if Platform == DECALPHA 
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
-	using std::find_if;
-#elif Platform == I7XEON
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-#elif Platform == XCMAC
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else							
-	using std::find_if;
-#endif					
 
 //////////////////////////////////////////////////////////////////////
 // Global members

--- a/src/evLamellaBilayerPhaseSeparation.cpp
+++ b/src/evLamellaBilayerPhaseSeparation.cpp
@@ -29,29 +29,6 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 #include "CompositeBilayer.h"
 
 
-#if Platform == DECALPHA 
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
-	using std::find_if;
-#elif Platform == I7XEON
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-#elif Platform == XCMAC
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else							
-	using std::find_if;
-#endif					
 
 //////////////////////////////////////////////////////////////////////
 // Global members

--- a/src/evLamellaMonolayerDomain.cpp
+++ b/src/evLamellaMonolayerDomain.cpp
@@ -31,35 +31,6 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 #include "Builder.h"		// Needed for the global pi
 
 
-#if Platform == DECALPHA 
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
-	using std::sort;
-	using std::set_intersection;
-#elif Platform == I7XEON
-	using std::sort;
-	using std::set_intersection;
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-	using std::sort;
-	using std::set_intersection;
-#elif Platform == XCMAC
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else							
-	using std::sort;
-	using std::set_intersection;
-#endif					
 
 //////////////////////////////////////////////////////////////////////
 // Global members

--- a/src/evLamellaMonolayerPhaseSeparation.cpp
+++ b/src/evLamellaMonolayerPhaseSeparation.cpp
@@ -30,35 +30,6 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 #include "Builder.h"		// Needed for the global pi
 
 
-#if Platform == DECALPHA 
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
-	using std::sort;
-	using std::set_intersection;
-#elif Platform == I7XEON
-	using std::sort;
-	using std::set_intersection;
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-	using std::sort;
-	using std::set_intersection;
-#elif Platform == XCMAC
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else							
-	using std::sort;
-	using std::set_intersection;
-#endif					
 
 //////////////////////////////////////////////////////////////////////
 // Global members

--- a/src/mcSaveCommandHistoryToCurrentTimeImpl.cpp
+++ b/src/mcSaveCommandHistoryToCurrentTimeImpl.cpp
@@ -28,32 +28,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 // STL using declarations
 
-#if Platform == DECALPHA 
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
 	using std::remove_if;
-#elif Platform == I7XEON
-	using std::remove_if;
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-	using std::remove_if;
-#elif Platform == XCMAC
-	using std::remove_if;
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else							
-	using std::remove_if;
-#endif			
 
 
 //////////////////////////////////////////////////////////////////////

--- a/src/prBLMVesicleFusion.cpp
+++ b/src/prBLMVesicleFusion.cpp
@@ -80,31 +80,6 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 // STL using declarations
 
-#if Platform == DECALPHA 
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
-	using std::find;
-	using std::find_if;
-#elif Platform == I7XEON
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-#elif Platform == XCMAC
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else							
-	using std::find;
-	using std::find_if;
-#endif					
 
 //////////////////////////////////////////////////////////////////////
 // Global members

--- a/src/prBeadDensityFluctuations.cpp
+++ b/src/prBeadDensityFluctuations.cpp
@@ -36,31 +36,6 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 // STL using declarations
 
-#if Platform == DECALPHA 
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
-	using std::find;
-	using std::find_if;
-#elif Platform == I7XEON
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-#elif Platform == XCMAC
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else							
-	using std::find;
-	using std::find_if;
-#endif					
 
 //////////////////////////////////////////////////////////////////////
 // Global members

--- a/src/prBeadKineticTemperatures.cpp
+++ b/src/prBeadKineticTemperatures.cpp
@@ -35,31 +35,6 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 // STL using declarations
 
-#if Platform == DECALPHA 
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
-	using std::find;
-	using std::find_if;
-#elif Platform == I7XEON
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-#elif Platform == XCMAC
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else							
-	using std::find;
-	using std::find_if;
-#endif					
 
 //////////////////////////////////////////////////////////////////////
 // Global members

--- a/src/prBeadVelocityScalarProduct1dProfile.cpp
+++ b/src/prBeadVelocityScalarProduct1dProfile.cpp
@@ -35,31 +35,6 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 // STL using declarations
 
-#if Platform == DECALPHA 
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
-	using std::find;
-	using std::find_if;
-#elif Platform == I7XEON
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-#elif Platform == XCMAC
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else							
-	using std::find;
-	using std::find_if;
-#endif					
 
 //////////////////////////////////////////////////////////////////////
 // Global members

--- a/src/prBilayerFusion.cpp
+++ b/src/prBilayerFusion.cpp
@@ -46,31 +46,6 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 // STL using declarations
 
-#if Platform == DECALPHA 
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
-	using std::find;
-	using std::find_if;
-#elif Platform == I7XEON
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-#elif Platform == XCMAC
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else							
-	using std::find;
-	using std::find_if;
-#endif					
 
 //////////////////////////////////////////////////////////////////////
 // Global members

--- a/src/prBilayerRaft.cpp
+++ b/src/prBilayerRaft.cpp
@@ -34,31 +34,6 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 // STL using declarations
 
-#if Platform == DECALPHA 
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
-	using std::find;
-	using std::find_if;
-#elif Platform == I7XEON
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-#elif Platform == XCMAC
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else							
-	using std::find;
-	using std::find_if;
-#endif					
 
 //////////////////////////////////////////////////////////////////////
 // Global members

--- a/src/prBilayerRuptureSurfactant.cpp
+++ b/src/prBilayerRuptureSurfactant.cpp
@@ -33,31 +33,6 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 // STL using declarations
 
-#if Platform == DECALPHA 
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
-	using std::find;
-	using std::find_if;
-#elif Platform == I7XEON
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-#elif Platform == XCMAC
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else							
-	using std::find;
-	using std::find_if;
-#endif					
 
 //////////////////////////////////////////////////////////////////////
 // Global members

--- a/src/prBilayerRuptureTension.cpp
+++ b/src/prBilayerRuptureTension.cpp
@@ -33,31 +33,6 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 // STL using declarations
 
-#if Platform == DECALPHA 
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
-	using std::find;
-	using std::find_if;
-#elif Platform == I7XEON
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-#elif Platform == XCMAC
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else							
-	using std::find;
-	using std::find_if;
-#endif					
 
 //////////////////////////////////////////////////////////////////////
 // Global members

--- a/src/prCommandContainer.cpp
+++ b/src/prCommandContainer.cpp
@@ -29,33 +29,6 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 // STL using declarations
 
-#if Platform == DECALPHA 
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
-	using std::find;
-	using std::find_if;
-	using std::ios_base;
-#elif Platform == I7XEON
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-#elif Platform == XCMAC
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else							
-	using std::find;
-	using std::find_if;
-	using std::ios_base;
-#endif	
 				
 //////////////////////////////////////////////////////////////////////
 // Global members

--- a/src/prCommandDocument.cpp
+++ b/src/prCommandDocument.cpp
@@ -56,33 +56,6 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 // STL using declarations
 
-#if Platform == DECALPHA 
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
-	using std::find;
-	using std::find_if;
-	using std::ios_base;
-#elif Platform == I7XEON
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-#elif Platform == XCMAC
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else							
-	using std::find;
-	using std::find_if;
-	using std::ios_base;
-#endif	
 				
 //////////////////////////////////////////////////////////////////////
 // Global members

--- a/src/prCommandQueue.cpp
+++ b/src/prCommandQueue.cpp
@@ -30,53 +30,10 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 // STL using declarations
 
-#if Platform == DECALPHA 
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
-	#include <limits>
-	using std::numeric_limits;
-	using std::streamsize;
-	using std::find;
-	using std::find_if;
-	using std::ios_base;
-#elif Platform == I7XEON
-	#include <limits>
-	using std::numeric_limits;
-	using std::streamsize;
-	using std::find;
-	using std::find_if;
-	using std::ios_base;
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
 	#include <limits>
 	using std::numeric_limits;
 	using std::streamsize;
 	using std::ios_base;
-#elif Platform == XCMAC
-	#include <limits>
-	using std::numeric_limits;
-	using std::streamsize;
-	using std::ios_base;
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else				
-	#include <limits>
-	using std::numeric_limits;
-	using std::streamsize;
-	using std::find;
-	using std::find_if;
-	using std::ios_base;
-#endif	
 				
 //////////////////////////////////////////////////////////////////////
 // Global members

--- a/src/prFormin.cpp
+++ b/src/prFormin.cpp
@@ -47,31 +47,6 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 // STL using declarations
 
-#if Platform == DECALPHA 
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
-	using std::find;
-	using std::find_if;
-#elif Platform == I7XEON
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-#elif Platform == XCMAC
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else							
-	using std::find;
-	using std::find_if;
-#endif					
 
 //////////////////////////////////////////////////////////////////////
 // Global members

--- a/src/prReceptor.cpp
+++ b/src/prReceptor.cpp
@@ -47,31 +47,6 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 // STL using declarations
 
-#if Platform == DECALPHA 
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
-	using std::find;
-	using std::find_if;
-#elif Platform == I7XEON
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-#elif Platform == XCMAC
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else							
-	using std::find;
-	using std::find_if;
-#endif					
 
 //////////////////////////////////////////////////////////////////////
 // Global members

--- a/src/prVesicleFusion.cpp
+++ b/src/prVesicleFusion.cpp
@@ -45,31 +45,6 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 // STL using declarations
 
-#if Platform == DECALPHA 
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
-	using std::find;
-	using std::find_if;
-#elif Platform == I7XEON
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-#elif Platform == XCMAC
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else							
-	using std::find;
-	using std::find_if;
-#endif					
 
 //////////////////////////////////////////////////////////////////////
 // Global members

--- a/src/prVesicleShear.cpp
+++ b/src/prVesicleShear.cpp
@@ -37,31 +37,6 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 // STL using declarations
 
-#if Platform == DECALPHA 
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
-	using std::find;
-	using std::find_if;
-#elif Platform == I7XEON
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-#elif Platform == XCMAC
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else							
-	using std::find;
-	using std::find_if;
-#endif					
 
 //////////////////////////////////////////////////////////////////////
 // Global members

--- a/src/prfActin.cpp
+++ b/src/prfActin.cpp
@@ -47,31 +47,6 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 // STL using declarations
 
-#if Platform == DECALPHA 
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
-	using std::find;
-	using std::find_if;
-#elif Platform == I7XEON
-#elif Platform == I7ITANIUM
-#elif Platform == GCC
-#elif Platform == CW55MAC
-#elif Platform == XCMAC
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else							
-	using std::find;
-	using std::find_if;
-#endif					
 
 //////////////////////////////////////////////////////////////////////
 // Global members

--- a/src/xxBase.cpp
+++ b/src/xxBase.cpp
@@ -275,15 +275,7 @@ void xxBase::TraceEndl() const
 {
 #if SimMPS == SimulationDisabled
 
-#if Platform == DECALPHA
 	std::cout << zEndl;
-#elif Platform == SGICC
-	cout << zEndl;
-#elif Platform == CRAYJ90
-	cout << zEndl;
-#else
-	std::cout << zEndl;
-#endif
 
 #endif
 }
@@ -292,15 +284,7 @@ void xxBase::TraceStringNoEndl(zString msgStr) const
 {
 #if SimMPS == SimulationDisabled
 
-#if Platform == DECALPHA
 	std::cout << msgStr.c_str() << "  ";
-#elif Platform == SGICC
-	cout << msgStr.c_str() << "  ";
-#elif Platform == CRAYJ90
-	cout << msgStr.c_str() << "  ";
-#else
-	std::cout << msgStr.c_str() << "  ";
-#endif
 
 #endif
 }
@@ -309,15 +293,7 @@ void xxBase::TraceIntNoEndl(long var1) const
 {
 #if SimMPS == SimulationDisabled
 
-#if Platform == DECALPHA
 	std::cout << var1 << " ";
-#elif Platform == SGICC
-	cout << var1 << " ";
-#elif Platform == CRAYJ90
-	cout << var1 << " ";
-#else
-	std::cout << var1 << " ";
-#endif
 
 #endif
 }
@@ -326,15 +302,7 @@ void xxBase::TraceDoubleNoEndl(double var1) const
 {
 #if SimMPS == SimulationDisabled
 
-#if Platform == DECALPHA
 	std::cout << var1 << " ";
-#elif Platform == SGICC
-	cout << var1 << " ";
-#elif Platform == CRAYJ90
-	cout << var1 << " ";
-#else
-	std::cout << var1 << " ";
-#endif
 
 #endif
 
@@ -347,15 +315,7 @@ void xxBase::TraceVector(zString msgStr, double var1, double var2, double var3) 
 {
 #if SimMPS == SimulationDisabled
 
-#if Platform == DECALPHA
 	std::cout << msgStr.c_str() << "  " << var1 << "  " << var2 << "  " << var3 << zEndl;
-#elif Platform == SGICC
-	cout << msgStr.c_str() << "  " << var1 << "  " << var2 << "  " << var3 << zEndl;
-#elif Platform == CRAYJ90
-	cout << msgStr.c_str() << "  " << var1 << "  " << var2 << "  " << var3 << zEndl;
-#else
-	std::cout << msgStr.c_str() << "  " << var1 << "  " << var2 << "  " << var3 << zEndl;
-#endif
 
 #endif
 }

--- a/src/xxProcess.cpp
+++ b/src/xxProcess.cpp
@@ -44,29 +44,6 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 // STL using declarations
 
-#if Platform == DECALPHA
-	using std::find_if;
-#elif Platform == SGICC
-#elif Platform == CRAYJ90
-#elif Platform == BORLAND6
-	using std::find_if;
-#elif Platform == I7XEON
-#elif Platform == I7ITANIUM
-#elif Platform == CW55MAC
-#elif Platform == XCMAC
-#elif Platform == NEWPLATFORM1
-#elif Platform == NEWPLATFORM2
-#elif Platform == NEWPLATFORM3
-#elif Platform == NEWPLATFORM4
-#elif Platform == NEWPLATFORM5
-#elif Platform == NEWPLATFORM6
-#elif Platform == NEWPLATFORM7
-#elif Platform == NEWPLATFORM8
-#elif Platform == NEWPLATFORM9
-#elif Platform == NEWPLATFORM10
-#else
-	using std::find_if;
-#endif					
 
 
 // **********************************************************************


### PR DESCRIPTION
* C++ is standardized enough now that these work-arounds shouldn't be
  needed