### PR TITLE
Dt10 saxs

### DIFF
--- a/examples/dmpci.micelle-SAXS
+++ b/examples/dmpci.micelle-SAXS
@@ -1,0 +1,77 @@
+dpd
+
+Title	" Micellet in water  "
+Date	19/05/21
+Comment	" Two types of polymer pre-assembled into a micelle.
+
+  "
+
+
+State   micelle
+        Polymers   Surfactant Alcohol
+        Centre     0.5  0.5  0.5
+        Radius     5
+
+
+Bead	W
+    	0.5
+    	25	
+    	4.5	
+
+Bead	H
+    	0.5
+    	25  25
+    	4.5   4.5
+
+Bead	T
+    	0.5
+    	25  25    25
+    	4.5   4.5   4.5
+
+Bead	OH
+    	0.5
+    	25  25    25     25
+    	4.5   4.5   4.5    4.5
+
+
+
+
+Bond	H H	 128	0.5
+Bond	H T  128    0.5
+Bond	T T  128    0.5
+
+Bond	OH T   128    0.5
+
+BondPair H T T    20.0  0.0
+BondPair T T T    20.0  0.0
+BondPair OH T T   20.0  0.0
+
+Polymer Water          0.930   " (W) "
+Polymer Surfactant     0.060    " (H H T T T T)  "
+Polymer Alcohol        0.010   " (OH T T)  "
+
+
+Box		24 24 24			1 1 1
+Density		3
+Temp		1
+RNGSeed		-887022
+Lambda		0.5
+Step		0.001
+Time		200
+SamplePeriod	10
+AnalysisPeriod	100
+DensityPeriod	100
+DisplayPeriod   100
+RestartPeriod	100
+Grid		1 1 1
+    
+
+Command	ToggleBeadDisplay              1   W
+Command	SetCurrentStateCamera	       1   0.5 -1.5 0.5  0.5 0.5 0.5
+
+Command SetCurrentStateDefaultFormat   1 Paraview
+
+Command SaveSAXS 1  1 100   0 0    0 1 1 -1
+Command SetSAXSProcessBeadElectronNo 1 1 H 1
+Command SetSAXSProcessBeadElectronNo 1 1 T 2
+Command SetSAXSProcessBeadElectronNo 1 1 OH 3

--- a/src/Builder.cpp
+++ b/src/Builder.cpp
@@ -34,6 +34,8 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 #include "LogBuilderError.h"
 #include "LogVelDistMessage.h"	// needed to output the initial velocity distribution
 
+#include <random>
+
 
 // STL using declarations
 
@@ -49,6 +51,20 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 //////////////////////////////////////////////////////////////////////
 // Static variable definitions
 //////////////////////////////////////////////////////////////////////
+
+// This is a wrapper to allow compilation on C++17 where std::random_shuffle has been removed.
+// The shuffle produced will be different to random_shuffle, but that order is implementation
+// defined and may not even be stable between runs.
+
+// This is shared. If the Builder code becomes multi-threaded then there
+// is a potential issue.
+static std::mt19937_64 g_ShuffleRng;
+
+template<class T>
+static void random_shuffle_wrapper(T begin, T end)
+{
+	std::shuffle(begin, end, g_ShuffleRng);
+}
 
 
 //////////////////////////////////////////////////////////////////////
@@ -1028,10 +1044,10 @@ bool CBuilder::isBilayer::Assemble(CInitialState& riState)
 	// Patches of polymers are specified for each monolayer independently
 
 	if(!m_bPatches[0])
-		random_shuffle(m_RandomUpperIndex.begin(), m_RandomUpperIndex.end());
+		random_shuffle_wrapper(m_RandomUpperIndex.begin(), m_RandomUpperIndex.end());
 	
 	if(!m_bPatches[1])
-		random_shuffle(m_RandomLowerIndex.begin(), m_RandomLowerIndex.end());
+		random_shuffle_wrapper(m_RandomLowerIndex.begin(), m_RandomLowerIndex.end());
 
 	// ****************************************
 	// Loop over the number of vertices in the lattices. We have to take care 
@@ -1594,10 +1610,10 @@ bool CBuilder::isFreeBilayer::Assemble(CInitialState& riState)
 	// Patches of polymers are specified for each monolayer independently
 
 	if(!m_bPatches[0])
-		random_shuffle(m_RandomUpperIndex.begin(), m_RandomUpperIndex.end());
+		random_shuffle_wrapper(m_RandomUpperIndex.begin(), m_RandomUpperIndex.end());
 	
 	if(!m_bPatches[1])
-		random_shuffle(m_RandomLowerIndex.begin(), m_RandomLowerIndex.end());
+		random_shuffle_wrapper(m_RandomLowerIndex.begin(), m_RandomLowerIndex.end());
 
 	// ****************************************
 	// Loop over the number of vertices in the lattices. We have to take care 
@@ -2118,8 +2134,8 @@ bool CBuilder::isMultiBilayer::Assemble(CInitialState& riState)
 
 	// No patches are allowed
 
-	random_shuffle(m_RandomUpperIndex.begin(), m_RandomUpperIndex.end());
-	random_shuffle(m_RandomLowerIndex.begin(), m_RandomLowerIndex.end());
+	random_shuffle_wrapper(m_RandomUpperIndex.begin(), m_RandomUpperIndex.end());
+	random_shuffle_wrapper(m_RandomLowerIndex.begin(), m_RandomLowerIndex.end());
 
 	// ****************************************
 	// Loop over the number of vertices in the lattices. We have to take care 
@@ -2789,7 +2805,7 @@ bool CBuilder::isWormMicelle::Assemble(CInitialState& riState)
 	// in the order they are defined
 
 	if(!m_bPatches)
-		random_shuffle(m_RandomIndex.begin(), m_RandomIndex.end());
+		random_shuffle_wrapper(m_RandomIndex.begin(), m_RandomIndex.end());
 
 	// Loop over the number of lipids in the micelle and assign coordinates to 
 	// the polymers with their tails positioned at the coordinates in the 
@@ -3585,10 +3601,10 @@ bool CBuilder::isVesicle::Assemble(CInitialState& riState)
 	// Patches of polymers are specified for each monolayer independently
 
 	if(!m_bPatches[0])
-		random_shuffle(m_RandomOuterIndex.begin(), m_RandomOuterIndex.end());
+		random_shuffle_wrapper(m_RandomOuterIndex.begin(), m_RandomOuterIndex.end());
 
 	if(!m_bPatches[1])
-		random_shuffle(m_RandomInnerIndex.begin(), m_RandomInnerIndex.end());
+		random_shuffle_wrapper(m_RandomInnerIndex.begin(), m_RandomInnerIndex.end());
 
 	// ****************************************
 	// Loop over each type of polymer in the monolayers and assign coordinates to 
@@ -4029,10 +4045,10 @@ bool CBuilder::isMultiVesicle::Assemble(CInitialState& riState)
 	// Patches of polymers are specified for each monolayer independently
 
 	if(!m_bPatches[0])
-		random_shuffle(m_RandomOuterIndex.begin(), m_RandomOuterIndex.end());
+		random_shuffle_wrapper(m_RandomOuterIndex.begin(), m_RandomOuterIndex.end());
 
 	if(!m_bPatches[1])
-		random_shuffle(m_RandomInnerIndex.begin(), m_RandomInnerIndex.end());
+		random_shuffle_wrapper(m_RandomInnerIndex.begin(), m_RandomInnerIndex.end());
 
 	// ****************************************
 	// Loop over each type of polymer in the monolayers and assign coordinates to 

--- a/src/LamellaBuilder.cpp
+++ b/src/LamellaBuilder.cpp
@@ -32,7 +32,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 #include "LogState.h"
 #include "LogBuilderError.h"	// needed to log errors assembling the initial state
 
-
+#include <random>
 
 
 //////////////////////////////////////////////////////////////////////
@@ -881,7 +881,9 @@ bool CLamellaBuilder::Assemble(CInitialState& riState)
 			// vector because we cannot change the vector's size while iterating
 			// through it.
 
-			random_shuffle(m_vPolymerisedBonds.begin(), m_vPolymerisedBonds.end());
+			// Remove random_shuffle to make it compile on c++17
+			std::minstd_rand rng(rand());
+			std::shuffle(m_vPolymerisedBonds.begin(), m_vPolymerisedBonds.end(), rng);
 
 			const long removeNo = static_cast<long>((1.0 - m_PolymerisedFraction)*m_vPolymerisedBonds.size());
 

--- a/src/SimBox.cpp
+++ b/src/SimBox.cpp
@@ -246,9 +246,13 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 #include "LogToggleDPDBeadThermostat.h"
 #endif
 
+#include <functional>
 
 	using std::cout;
-	using std::mem_fun;
+
+// Could do compile-time tricks to change alias, if compilers below C++11 need support?
+using std::mem_fn; // Covert to std::mem_fn, as mem_fun deprecated in c++17
+
 
 //////////////////////////////////////////////////////////////////////
 // Construction/Destruction
@@ -1627,7 +1631,7 @@ void CSimBox::FreezeBeadsInSlice(const xxCommand *const pCommand)
 
 			BeadList beads = pCell->GetBeads();
 
-			for_each(beads.begin(), beads.end(), mem_fun(&CAbstractBead::SetFrozen));
+			for_each(beads.begin(), beads.end(), mem_fn(&CAbstractBead::SetFrozen));
 
 			beadsFrozen += beads.size();
 		}
@@ -5304,7 +5308,7 @@ void CSimBox::FreezeBeadsInTarget(const xxCommand* const pCommand)
 
 		BeadVector vBeads = pCmdTarget->GetBeads();
 
-		for_each(vBeads.begin(), vBeads.end(), mem_fun(&CAbstractBead::SetFrozen));
+		for_each(vBeads.begin(), vBeads.end(), mem_fn(&CAbstractBead::SetFrozen));
 
 		new CLogctFreezeBeadsInTarget(m_SimTime, targetLabel);
 	}
@@ -5345,7 +5349,7 @@ void CSimBox::UnFreezeBeadsInTarget(const xxCommand* const pCommand)
 
 		BeadVector vBeads = pCmdTarget->GetBeads();
 
-		for_each(vBeads.begin(), vBeads.end(), mem_fun(&CAbstractBead::SetNotFrozen));
+		for_each(vBeads.begin(), vBeads.end(), mem_fn(&CAbstractBead::SetNotFrozen));
 
 		new CLogctUnFreezeBeadsInTarget(m_SimTime, targetLabel);
 	}

--- a/src/aeCNTCell.cpp
+++ b/src/aeCNTCell.cpp
@@ -22,9 +22,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 #include "aeCNTCell.h"
 #include "aeActiveBond.h"
 
-// STL using declarations
-
-	using std::random_shuffle;
+#include <random>
 
 
 //////////////////////////////////////////////////////////////////////
@@ -280,7 +278,10 @@ aeActiveBond* aeCNTCell::UpdatePolymerisation(aeActiveBond* const pBond)
 		copy(lNNBonds.begin(), lNNBonds.end(), back_inserter(vLocalBonds));
     }
 
-	random_shuffle(vLocalBonds.begin(), vLocalBonds.end());
+	// Used shuffle, as random_shuffle deprecated in C++17
+	// Shuffle is implementation defined, but so was random_shuffle
+	std::minstd_rand rng(rand());
+	shuffle(vLocalBonds.begin(), vLocalBonds.end(), rng);
 
     ActiveBondIterator iterBond=vLocalBonds.begin();
 	aeActiveBond* pTargetBond = 0;

--- a/src/mcSaveSAXS.cpp
+++ b/src/mcSaveSAXS.cpp
@@ -276,9 +276,12 @@ bool mcSaveSAXS::IsDataValid(const CInputData& riData) const
     }
 
     end = start + duration;
-    
-    if( end > riData.GetTotalTime() || duration%riData.GetSamplePeriod() != 0)
-		return ErrorTrace("Invalid duration or multiple of SamplePeriod for SAXS analysis");
+
+
+    if( end > riData.GetTotalTime())
+        return ErrorTrace("Invalid duration for SAXS analysis, total time="+std::to_string(riData.GetTotalTime())+", end="+std::to_string(end));
+    else if (duration%riData.GetSamplePeriod() != 0)
+		return ErrorTrace("Duration is not a multiple of SamplePeriod for SAXS analysis");
     else
 	    return true;
 }

--- a/src/prSAXS.cpp
+++ b/src/prSAXS.cpp
@@ -310,7 +310,7 @@ void prSAXS::UpdateState(CSimState& rSimState, const ISimBox* const pISimBox)
 
 		std::cout << "Sample " <<  m_SamplesTaken << " of I(q) at time " << pISimBox->GetCurrentTime() << " " << m_QMin << " " << m_QMax << " " << m_dQ << " " << m_QPoints << zEndl;
 
-        const bool verify=true;
+        const bool verify=false;
         if(verify){
             std::vector<double> origIq=m_vIQ;
             std::vector<double> origIqSqr=m_vIQSq;

--- a/src/prSAXS.cpp
+++ b/src/prSAXS.cpp
@@ -29,6 +29,11 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 #include "TimeSeriesData.h"
 #include "InputData.h"
 
+#include <unistd.h>
+#include <algorithm>
+#include <numeric>
+#include <thread>
+
 
 //////////////////////////////////////////////////////////////////////
 // Global members
@@ -40,6 +45,13 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 // xxProcess-derived class so that it can create the appropriate object 
 // to hold the process data.
 //
+
+static double now()
+{
+    timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return ts.tv_sec + ts.tv_nsec*1e-9;
+}
     
 const zString prSAXS::m_Type = "SAXS";
 
@@ -297,88 +309,35 @@ void prSAXS::UpdateState(CSimState& rSimState, const ISimBox* const pISimBox)
 		m_SamplesTaken++;
 
 		std::cout << "Sample " <<  m_SamplesTaken << " of I(q) at time " << pISimBox->GetCurrentTime() << " " << m_QMin << " " << m_QMax << " " << m_dQ << " " << m_QPoints << zEndl;
- 						
-		double dx[3];
-        
-        // Define the min and max q values from the box size and bead diameter.
-    
-        // Loop over all q values, adding the contributions from each bead pair weighted by their electon numbers.
-        // To svoid double counting, we start the second loop with the iterator equal to the first.
-        
-        double qvalue = m_QMin;
-    
-        for(long iq = 0; iq < m_QPoints; ++iq)
-        {
-            for(cBeadVectorIterator iterBead1 = m_vBeads.begin(); iterBead1!=m_vBeads.end(); ++iterBead1)
-			{
-                const double eno1 = m_mElectronNo.find((*iterBead1)->GetType())->second;
 
-                 // Include the double counting of off diagonal elements
-                
-                for(cBeadVectorIterator iterBead2 = m_vBeads.begin(); iterBead2!=m_vBeads.end(); ++iterBead2)
-				{
-                    const double eno2 = m_mElectronNo.find((*iterBead2)->GetType())->second;
-        
-                    dx[0] = (*iterBead1)->GetXPos() - (*iterBead2)->GetXPos();
-                    dx[1] = (*iterBead1)->GetYPos() - (*iterBead2)->GetYPos();
-                    dx[2] = (*iterBead1)->GetZPos() - (*iterBead2)->GetZPos();
+        const bool verify=true;
+        if(verify){
+            std::vector<double> origIq=m_vIQ;
+            std::vector<double> origIqSqr=m_vIQSq;
 
-                    // Correct for the PBCs
-/*
-                    if( dx[0] > IGlobalSimBox::Instance()->GetHalfSimBoxXLength() )
-                        dx[0] = dx[0] - IGlobalSimBox::Instance()->GetSimBoxXLength();
-                    else if( dx[0] < -IGlobalSimBox::Instance()->GetHalfSimBoxXLength() )
-                        dx[0] = dx[0] + IGlobalSimBox::Instance()->GetSimBoxXLength();
-
-                    if( dx[1] > IGlobalSimBox::Instance()->GetHalfSimBoxYLength() )
-                        dx[1] = dx[1] - IGlobalSimBox::Instance()->GetSimBoxYLength();
-                    else if( dx[1] < -IGlobalSimBox::Instance()->GetHalfSimBoxYLength() )
-                        dx[1] = dx[1] + IGlobalSimBox::Instance()->GetSimBoxYLength();
-
-                    #if SimDimension == 3
-                    dx[2] = (*iterBead1)->GetZPos() - (*iterBead2)->GetZPos();
-
-                    if( dx[2] > IGlobalSimBox::Instance()->GetHalfSimBoxZLength() )
-                        dx[2] = dx[2] - IGlobalSimBox::Instance()->GetSimBoxZLength();
-                    else if( dx[2] < -IGlobalSimBox::Instance()->GetHalfSimBoxZLength() )
-                        dx[2] = dx[2] + IGlobalSimBox::Instance()->GetSimBoxZLength();
-                    #else
-                        dx[2] = 0.0;
-                    #endif
-*/
-                     double dr = sqrt(dx[0]*dx[0] + dx[1]*dx[1] + dx[2]*dx[2]);
-                        
-//                    std::cout << "out: iq " << iq << " " << qvalue << " " << eno1 << " " << eno2 << " " << dr << zEndl;
-
-                    
-                    if(dr > 0.000001)
-                    {
-                        const double dvalue = (eno1*eno2*sin(qvalue*dr)/(qvalue*dr));
-                        m_vIQ.at(iq) += dvalue;
-                        m_vIQSq.at(iq) += dvalue*dvalue;
-
-//                        std::cout << "Diff: " << iq << " " << qvalue << " " << dvalue << zEndl;
-                    }
-                    else
-                    {
-                        // i = j here so we have the same bead, and because Sinx/x = 1 when x = 0, the contribution is just F(q)**2.
-                        
-                        const double eprod =eno1*eno2;
-                        m_vIQ.at(iq) += eprod;
-                        m_vIQSq.at(iq) += (eprod*eprod);
-
-//                        std::cout << "adding " << eno1 << " " << eno2 << " " << qvalue << " " << dr << zEndl;
-                    }
-                    
-				}
-			}
+            double begin=now();		
+            UpdateState_InnerLoop_ref(rSimState, pISimBox);
+            double end=now();
+            std::cout<<"   Ref took "<<(end-begin)<<"secs\n";
+            std::vector<double> refIq=m_vIQ;
+            std::vector<double> refIqSqr=m_vIQSq;
             
-            
-//            std::cout << "After: iq " << iq << " " << qvalue << " " << m_vIQ.at(iq) << zEndl;
-            
-           qvalue += m_dQ;
+
+            m_vIQ.assign(origIq.begin(), origIq.end());
+            m_vIQSq.assign(origIqSqr.begin(), origIqSqr.end());
+            begin=now();		
+            UpdateState_InnerLoop_v4_threads(rSimState, pISimBox);
+            end=now();
+            std::cout<<"   v2 took "<<(end-begin)<<"secs\n";
+
+            for(unsigned i=0; i<refIq.size(); i++){
+                std::cout<<"   "<<i<<", "<<refIq[i]<<", "<<m_vIQ[i]<<"\n";
+            }
+        }else{
+            UpdateState_InnerLoop_v4_threads(rSimState, pISimBox);
         }
-				
+
+
 		if(m_SamplesTaken == m_SampleTotal)
 		{
 			CTimeSeriesData* const pTSD = new CTimeSeriesData(m_QPoints+1);
@@ -411,6 +370,912 @@ void prSAXS::UpdateState(CSimState& rSimState, const ISimBox* const pISimBox)
      }
 
 }
+
+
+
+void prSAXS::UpdateState_InnerLoop_ref(CSimState& rSimState, const ISimBox* const pISimBox)
+{
+    double dx[3];
+        
+    // Define the min and max q values from the box size and bead diameter.
+
+    // Loop over all q values, adding the contributions from each bead pair weighted by their electon numbers.
+    // To svoid double counting, we start the second loop with the iterator equal to the first.
+    
+    double qvalue = m_QMin;
+
+    for(long iq = 0; iq < m_QPoints; ++iq)
+    {
+        if( (iq%10) == 0){
+            std::cerr<<iq<<" of "<<m_QPoints<<"\n";
+        }
+
+        for(cBeadVectorIterator iterBead1 = m_vBeads.begin(); iterBead1!=m_vBeads.end(); ++iterBead1)
+        {
+            const double eno1 = m_mElectronNo.find((*iterBead1)->GetType())->second;
+
+                // Include the double counting of off diagonal elements
+            
+            for(cBeadVectorIterator iterBead2 = m_vBeads.begin(); iterBead2!=m_vBeads.end(); ++iterBead2)
+            {
+                const double eno2 = m_mElectronNo.find((*iterBead2)->GetType())->second;
+    
+                dx[0] = (*iterBead1)->GetXPos() - (*iterBead2)->GetXPos();
+                dx[1] = (*iterBead1)->GetYPos() - (*iterBead2)->GetYPos();
+                dx[2] = (*iterBead1)->GetZPos() - (*iterBead2)->GetZPos();
+
+                // Correct for the PBCs
+/*
+                if( dx[0] > IGlobalSimBox::Instance()->GetHalfSimBoxXLength() )
+                    dx[0] = dx[0] - IGlobalSimBox::Instance()->GetSimBoxXLength();
+                else if( dx[0] < -IGlobalSimBox::Instance()->GetHalfSimBoxXLength() )
+                    dx[0] = dx[0] + IGlobalSimBox::Instance()->GetSimBoxXLength();
+
+                if( dx[1] > IGlobalSimBox::Instance()->GetHalfSimBoxYLength() )
+                    dx[1] = dx[1] - IGlobalSimBox::Instance()->GetSimBoxYLength();
+                else if( dx[1] < -IGlobalSimBox::Instance()->GetHalfSimBoxYLength() )
+                    dx[1] = dx[1] + IGlobalSimBox::Instance()->GetSimBoxYLength();
+
+                #if SimDimension == 3
+                dx[2] = (*iterBead1)->GetZPos() - (*iterBead2)->GetZPos();
+
+                if( dx[2] > IGlobalSimBox::Instance()->GetHalfSimBoxZLength() )
+                    dx[2] = dx[2] - IGlobalSimBox::Instance()->GetSimBoxZLength();
+                else if( dx[2] < -IGlobalSimBox::Instance()->GetHalfSimBoxZLength() )
+                    dx[2] = dx[2] + IGlobalSimBox::Instance()->GetSimBoxZLength();
+                #else
+                    dx[2] = 0.0;
+                #endif
+*/
+                    double dr = sqrt(dx[0]*dx[0] + dx[1]*dx[1] + dx[2]*dx[2]);
+                    
+//                    std::cout << "out: iq " << iq << " " << qvalue << " " << eno1 << " " << eno2 << " " << dr << zEndl;
+
+                
+                if(dr > 0.000001)
+                {
+                    const double dvalue = (eno1*eno2*sin(qvalue*dr)/(qvalue*dr));
+                    m_vIQ.at(iq) += dvalue;
+                    m_vIQSq.at(iq) += dvalue*dvalue;
+
+//                        std::cout << "Diff: " << iq << " " << qvalue << " " << dvalue << zEndl;
+                }
+                else
+                {
+                    // i = j here so we have the same bead, and because Sinx/x = 1 when x = 0, the contribution is just F(q)**2.
+                    
+                    const double eprod =eno1*eno2;
+                    m_vIQ.at(iq) += eprod;
+                    m_vIQSq.at(iq) += (eprod*eprod);
+
+//                        std::cout << "adding " << eno1 << " " << eno2 << " " << qvalue << " " << dr << zEndl;
+                }
+                
+            }
+        }
+        
+        
+//            std::cout << "After: iq " << iq << " " << qvalue << " " << m_vIQ.at(iq) << zEndl;
+        
+        qvalue += m_dQ;
+    }
+}
+
+double prSAXS::DistanceMetric(const CAbstractBead *a, const CAbstractBead *b) const
+{
+    double dx[3];
+    dx[0] = a->GetXPos() - b->GetXPos();
+    dx[1] = a->GetYPos() - b->GetYPos();
+    dx[2] = a->GetZPos() - b->GetZPos();
+    return sqrt(dx[0]*dx[0] + dx[1]*dx[1] + dx[2]*dx[2]);
+}
+
+float prSAXS::DistanceMetric(const float *a, const float *b) const
+{
+    float dx[3];
+    dx[0] = a[0] - b[0];
+    dx[1] = a[1] - b[1];
+    dx[2] = a[2] - b[2];
+    return sqrt(dx[0]*dx[0] + dx[1]*dx[1] + dx[2]*dx[2]);
+}
+
+void prSAXS::UpdateState_InnerLoop_v1(CSimState& rSimState, const ISimBox* const pISimBox)
+{        
+    // Define the min and max q values from the box size and bead diameter.
+
+    // Loop over all q values, adding the contributions from each bead pair weighted by their electon numbers.
+    // To svoid double counting, we start the second loop with the iterator equal to the first.
+
+    const auto &bead_types=rSimState.GetBeadTypes();
+    std::vector<double> enoCache(bead_types.size());
+    for(unsigned i=0; i<bead_types.size(); i++){
+        const auto pbt=bead_types[i];
+        assert(pbt->GetType()==i);
+        enoCache[i]=m_mElectronNo.at(i);
+    }
+    
+    for(cBeadVectorIterator iterBead1 = m_vBeads.begin(); iterBead1!=m_vBeads.end(); ++iterBead1)
+    {
+        const double eno1 = enoCache[(*iterBead1)->GetType()];
+
+        for(cBeadVectorIterator iterBead2 = m_vBeads.begin(); iterBead2!=m_vBeads.end(); ++iterBead2)
+        {
+            const double eprod = eno1 * enoCache[(*iterBead2)->GetType()];
+            const double dr = DistanceMetric(*iterBead1, *iterBead2);
+                            
+            if(dr > 0.000001)
+            {
+                for(long iq = 0; iq < m_QPoints; ++iq)
+                {
+                    const double qvalue = m_QMin + iq*m_dQ;
+                    const double dvalue = eprod*sin(qvalue*dr)/(qvalue*dr);
+                    m_vIQ[iq] += dvalue;
+                    m_vIQSq[iq] += dvalue*dvalue;
+                }
+            }
+            else
+            {
+                // i = j here so we have the same bead, and because Sinx/x = 1 when x = 0, the contribution is just F(q)**2.                
+                for(long iq = 0; iq < m_QPoints; ++iq)
+                {
+                    m_vIQ[iq] += eprod;
+                    m_vIQSq[iq] += (eprod*eprod);
+                }
+            }
+        }
+    }
+}
+
+
+void prSAXS::UpdateState_InnerLoop_v2(CSimState& rSimState, const ISimBox* const pISimBox)
+{        
+    // Define the min and max q values from the box size and bead diameter.
+
+    // Loop over all q values, adding the contributions from each bead pair weighted by their electon numbers.
+    // To svoid double counting, we start the second loop with the iterator equal to the first.
+
+    const auto &bead_types=rSimState.GetBeadTypes();
+    std::vector<float> enoCache(bead_types.size());
+    for(unsigned i=0; i<bead_types.size(); i++){
+        const auto pbt=bead_types[i];
+        assert(pbt->GetType()==i);
+        auto it= m_mElectronNo.find(i);
+        if(it!=m_mElectronNo.end()){
+            enoCache[i]=it->second;
+        }
+    }
+
+    struct bead_info_t
+    {
+        float x[3];
+        float eno;
+    };
+
+    std::vector<bead_info_t> pos_cache;
+    pos_cache.reserve(m_vBeads.size());
+    for(cBeadVectorIterator iterBead1 = m_vBeads.begin(); iterBead1!=m_vBeads.end(); ++iterBead1){
+        const auto &b=**iterBead1;
+        bead_info_t bi{
+            { (float)b.GetXPos(), (float)b.GetYPos(), (float)b.GetZPos()},
+            enoCache[b.GetType()]
+        };
+        pos_cache.push_back(bi);
+    }
+    
+    float QMin = m_QMin;
+    float dQ = m_dQ;
+
+    for(unsigned i1=0; i1<pos_cache.size(); i1++){
+        const auto &b1=pos_cache[i1];
+
+        const float esquare=b1.eno*b1.eno;
+        for(long iq = 0; iq < m_QPoints; ++iq)
+        {
+            m_vIQ[iq] += esquare;
+            m_vIQSq[iq] += (esquare*esquare);
+        }
+
+        for(unsigned i2=i1+1; i2<pos_cache.size(); i2++){
+            const auto &b2=pos_cache[i2];
+    
+            // We multiply by 2 here as this only does (i1<i2), so we need to double it to cover (i2<i1)
+            // (i1==i2) is covered by the earlier special-case loop
+            const float eprod = 2 * b1.eno * b2.eno;
+            const float dr = DistanceMetric(b1.x, b2.x);
+              
+            if(dr > 0.000001)
+            {
+                for(long iq = 0; iq < m_QPoints; iq++)
+                {
+                    const float qvalue = QMin + iq*dQ;
+                    // TODO: we are evaluating sin(ß (QMin+iq*dQ)*dr )
+                    //                         sin( QMin*dr + iq*(dQ*dr) )
+                    // So could be done with angle addition formula
+                    const float dvalue = eprod*sinf(qvalue*dr)/(qvalue*dr);
+                    // Accumulation is still double-precision
+                    m_vIQ[iq] += dvalue;
+                    m_vIQSq[iq] += dvalue*dvalue;
+                }
+            }
+            else
+            {
+                // i = j here so we have the same bead, and because Sinx/x = 1 when x = 0, the contribution is just F(q)**2.                
+                for(long iq = 0; iq < m_QPoints; ++iq)
+                {
+                    m_vIQ[iq] += eprod;
+                    m_vIQSq[iq] += (eprod*eprod);
+                }
+            }
+        }
+    }
+}
+
+
+
+struct sin_enum_angle_direct
+{
+    float x;
+    float dx;
+
+    sin_enum_angle_direct(float _x, float _dx)
+    {
+        x=_x;
+        dx=_dx;
+    }
+
+    float operator()()
+    {
+        float res=sinf(x);
+        x += dx;
+        return res;
+    }
+};
+struct sin_enum_angle_recurrence
+{
+    float cos_dx;
+    float sin_dx;
+    float sin_x;
+    float cos_x;
+
+    sin_enum_angle_recurrence(float x, float dx)
+    {
+        cos_x=cosf(x);
+        sin_x=sinf(x);
+        cos_dx=cosf(dx);
+        sin_dx=sinf(dx);
+    }
+
+    float operator()()
+    {
+        float res=sin_x;
+        float sin_x_next=sin_x * cos_dx + cos_x * sin_dx;
+        float cos_x_next=cos_x * cos_dx - sin_x * sin_dx;
+        sin_x = sin_x_next;
+        cos_x = cos_x_next;
+        return res;
+    }
+};
+
+void prSAXS::UpdateState_InnerLoop_v3(CSimState& rSimState, const ISimBox* const pISimBox)
+{        
+    // Define the min and max q values from the box size and bead diameter.
+
+    // Loop over all q values, adding the contributions from each bead pair weighted by their electon numbers.
+    // To svoid double counting, we start the second loop with the iterator equal to the first.
+
+    const auto &bead_types=rSimState.GetBeadTypes();
+    std::vector<float> enoCache(bead_types.size());
+    for(unsigned i=0; i<bead_types.size(); i++){
+        const auto pbt=bead_types[i];
+        assert(pbt->GetType()==i);
+        auto it= m_mElectronNo.find(i);
+        if(it!=m_mElectronNo.end()){
+            enoCache[i]=it->second;
+        }
+    }
+
+    struct bead_info_t
+    {
+        float x[3];
+        float eno;
+    };
+
+    std::vector<bead_info_t> pos_cache;
+    pos_cache.reserve(m_vBeads.size());
+    for(cBeadVectorIterator iterBead1 = m_vBeads.begin(); iterBead1!=m_vBeads.end(); ++iterBead1){
+        const auto &b=**iterBead1;
+        bead_info_t bi{
+            { (float)b.GetXPos(), (float)b.GetYPos(), (float)b.GetZPos()},
+            enoCache[b.GetType()]
+        };
+        pos_cache.push_back(bi);
+    }
+    
+    float QMin = m_QMin;
+    float dQ = m_dQ;
+
+    for(unsigned i1=0; i1<pos_cache.size(); i1++){
+        const auto &b1=pos_cache[i1];
+
+        const float esquare=b1.eno*b1.eno;
+        for(long iq = 0; iq < m_QPoints; ++iq)
+        {
+            m_vIQ[iq] += esquare;
+            m_vIQSq[iq] += (esquare*esquare);
+        }
+
+        for(unsigned i2=i1+1; i2<pos_cache.size(); i2++){
+            const auto &b2=pos_cache[i2];
+    
+            // We multiply by 2 here as this only does (i1<i2), so we need to double it to cover (i2<i1)
+            // (i1==i2) is covered by the earlier special-case loop
+            const float eprod = 2 * b1.eno * b2.eno;
+            const float dr = DistanceMetric(b1.x, b2.x);
+              
+            if(dr > 0.000001)
+            {
+                // We are evaluating sin(ß (QMin+iq*dQ)*dr )
+                //                         sin( QMin*dr + iq*(dQ*dr) )
+                sin_enum_angle_recurrence sin_enum(QMin*dr, dQ*dr);    
+                float qvalue=QMin;
+                float scale=eprod / dr;
+                for(long iq = 0; iq < m_QPoints; iq++)
+                {
+                    const float dvalue = scale*sin_enum() / qvalue;
+                    // Accumulation is still double-precision
+                    m_vIQ[iq] += dvalue;
+                    m_vIQSq[iq] += dvalue*dvalue;
+                    qvalue += dQ;
+                }
+            }
+            else
+            {
+                // i = j here so we have the same bead, and because Sinx/x = 1 when x = 0, the contribution is just F(q)**2.                
+                for(long iq = 0; iq < m_QPoints; ++iq)
+                {
+                    m_vIQ[iq] += eprod;
+                    m_vIQSq[iq] += (eprod*eprod);
+                }
+            }
+        }
+    }
+}
+
+void prSAXS::UpdateState_InnerLoop_v4(CSimState& rSimState, const ISimBox* const pISimBox)
+{        
+    // Define the min and max q values from the box size and bead diameter.
+
+    // Loop over all q values, adding the contributions from each bead pair weighted by their electon numbers.
+    // To svoid double counting, we start the second loop with the iterator equal to the first.
+
+    const auto &bead_types=rSimState.GetBeadTypes();
+    std::vector<float> enoCache(bead_types.size());
+    for(unsigned i=0; i<bead_types.size(); i++){
+        const auto pbt=bead_types[i];
+        assert(pbt->GetType()==i);
+        auto it= m_mElectronNo.find(i);
+        if(it!=m_mElectronNo.end()){
+            enoCache[i]=it->second;
+        }
+    }
+
+    struct bead_info_t
+    {
+        float x[3];
+        float eno;
+    };
+
+    std::vector<bead_info_t> pos_cache;
+    pos_cache.reserve(m_vBeads.size());
+    for(cBeadVectorIterator iterBead1 = m_vBeads.begin(); iterBead1!=m_vBeads.end(); ++iterBead1){
+        const auto &b=**iterBead1;
+        bead_info_t bi{
+            { (float)b.GetXPos(), (float)b.GetYPos(), (float)b.GetZPos()},
+            enoCache[b.GetType()]
+        };
+        pos_cache.push_back(bi);
+    }
+    
+    float QMin = m_QMin;
+    float dQ = m_dQ;
+
+    std::vector<float> vIQLocal(m_QPoints, 0.0f);
+    std::vector<float> vIQSqLocal(m_QPoints, 0.0f);
+
+    for(unsigned i1=0; i1<pos_cache.size(); i1++){
+        const auto &b1=pos_cache[i1];
+
+        const float esquare=b1.eno*b1.eno;
+        for(long iq = 0; iq < m_QPoints; ++iq)
+        {
+            vIQLocal[iq] += esquare;
+            vIQSqLocal[iq] += (esquare*esquare);
+        }
+
+        for(unsigned i2=i1+1; i2<pos_cache.size(); i2++){
+            const auto &b2=pos_cache[i2];
+    
+            // We multiply by 2 here as this only does (i1<i2), so we need to double it to cover (i2<i1)
+            // (i1==i2) is covered by the earlier special-case loop
+            const float eprod = 2 * b1.eno * b2.eno;
+            const float dr = DistanceMetric(b1.x, b2.x);
+              
+            if(dr > 0.000001)
+            {
+                // We are evaluating sin(ß (QMin+iq*dQ)*dr )
+                //                         sin( QMin*dr + iq*(dQ*dr) )
+                sin_enum_angle_recurrence sin_enum(QMin*dr, dQ*dr);    
+                float qvalue=QMin;
+                float scale=eprod / dr;
+                for(long iq = 0; iq < m_QPoints; iq++)
+                {
+                    const float dvalue = scale*sin_enum() / qvalue;
+                    // Accumulation is still double-precision
+                    vIQLocal[iq] += dvalue;
+                    vIQSqLocal[iq] += dvalue*dvalue;
+                    qvalue += dQ;
+                }
+            }
+            else
+            {
+                // i = j here so we have the same bead, and because Sinx/x = 1 when x = 0, the contribution is just F(q)**2.                
+                for(long iq = 0; iq < m_QPoints; ++iq)
+                {
+                    vIQLocal[iq] += eprod;
+                    vIQSqLocal[iq] += (eprod*eprod);
+                }
+            }
+        }
+
+        for(unsigned i=0; i<m_QPoints; i++){
+            m_vIQ[i] += vIQLocal[i];
+            m_vIQSq[i] += vIQSqLocal[i];
+            vIQLocal[i] = 0.0f;
+            vIQSqLocal[i] = 0.0f;
+        }
+    }
+}
+
+#if OSPREY_DPD_HAVE_OPENMP
+void prSAXS::UpdateState_InnerLoop_v4_omp(CSimState& rSimState, const ISimBox* const pISimBox)
+{        
+    // Define the min and max q values from the box size and bead diameter.
+
+    // Loop over all q values, adding the contributions from each bead pair weighted by their electon numbers.
+    // To svoid double counting, we start the second loop with the iterator equal to the first.
+
+    const auto &bead_types=rSimState.GetBeadTypes();
+    std::vector<float> enoCache(bead_types.size());
+    for(unsigned i=0; i<bead_types.size(); i++){
+        const auto pbt=bead_types[i];
+        assert(pbt->GetType()==i);
+        auto it= m_mElectronNo.find(i);
+        if(it!=m_mElectronNo.end()){
+            enoCache[i]=it->second;
+        }
+    }
+
+    struct bead_info_t
+    {
+        float x[3];
+        float eno;
+    };
+
+    std::vector<bead_info_t> pos_cache;
+    pos_cache.reserve(m_vBeads.size());
+    for(cBeadVectorIterator iterBead1 = m_vBeads.begin(); iterBead1!=m_vBeads.end(); ++iterBead1){
+        const auto &b=**iterBead1;
+        bead_info_t bi{
+            { (float)b.GetXPos(), (float)b.GetYPos(), (float)b.GetZPos()},
+            enoCache[b.GetType()]
+        };
+        pos_cache.push_back(bi);
+    }
+    
+    float QMin = m_QMin;
+    float dQ = m_dQ;
+
+    std::vector<float> vIQLocal(m_QPoints, 0.0f);
+    std::vector<float> vIQSqLocal(m_QPoints, 0.0f);
+
+    #pragma omp parallel for firstprivate(vIQLocal) firstprivate(vIQSqLocal)
+    for(unsigned i1=0; i1<pos_cache.size(); i1++){
+        const auto &b1=pos_cache[i1];
+
+        const float esquare=b1.eno*b1.eno;
+        for(long iq = 0; iq < m_QPoints; ++iq)
+        {
+            vIQLocal[iq] += esquare;
+            vIQSqLocal[iq] += (esquare*esquare);
+        }
+
+        for(unsigned i2=i1+1; i2<pos_cache.size(); i2++){
+            const auto &b2=pos_cache[i2];
+    
+            // We multiply by 2 here as this only does (i1<i2), so we need to double it to cover (i2<i1)
+            // (i1==i2) is covered by the earlier special-case loop
+            const float eprod = 2 * b1.eno * b2.eno;
+            const float dr = DistanceMetric(b1.x, b2.x);
+              
+            if(dr > 0.000001)
+            {
+                // We are evaluating sin(ß (QMin+iq*dQ)*dr )
+                //                         sin( QMin*dr + iq*(dQ*dr) )
+                sin_enum_angle_recurrence sin_enum(QMin*dr, dQ*dr);    
+                float qvalue=QMin;
+                float scale=eprod / dr;
+                for(long iq = 0; iq < m_QPoints; iq++)
+                {
+                    const float dvalue = scale*sin_enum() / qvalue;
+                    // Accumulation is still double-precision
+                    vIQLocal[iq] += dvalue;
+                    vIQSqLocal[iq] += dvalue*dvalue;
+                    qvalue += dQ;
+                }
+            }
+            else
+            {
+                // i = j here so we have the same bead, and because Sinx/x = 1 when x = 0, the contribution is just F(q)**2.                
+                for(long iq = 0; iq < m_QPoints; ++iq)
+                {
+                    vIQLocal[iq] += eprod;
+                    vIQSqLocal[iq] += (eprod*eprod);
+                }
+            }
+        }
+
+        #pragma omp critical
+        {
+            // This is not too bad as long is m_QPoints is small
+            for(unsigned i=0; i<m_QPoints; i++){
+                m_vIQ[i] += vIQLocal[i];
+                m_vIQSq[i] += vIQSqLocal[i];
+                vIQLocal[i] = 0.0f;
+                vIQSqLocal[i] = 0.0f;
+            }
+        }
+    }
+}
+#endif
+
+#if OSPREY_DPD_HAVE_STL_PARALLEL
+void prSAXS::UpdateState_InnerLoop_v4_stl_parallel(CSimState& rSimState, const ISimBox* const pISimBox)
+{        
+    // Define the min and max q values from the box size and bead diameter.
+
+    // Loop over all q values, adding the contributions from each bead pair weighted by their electon numbers.
+    // To svoid double counting, we start the second loop with the iterator equal to the first.
+
+    const auto &bead_types=rSimState.GetBeadTypes();
+    std::vector<float> enoCache(bead_types.size());
+    for(unsigned i=0; i<bead_types.size(); i++){
+        const auto pbt=bead_types[i];
+        assert(pbt->GetType()==i);
+        auto it= m_mElectronNo.find(i);
+        if(it!=m_mElectronNo.end()){
+            enoCache[i]=it->second;
+        }
+    }
+
+    struct bead_info_t
+    {
+        float x[3];
+        float eno;
+    };
+
+    std::vector<bead_info_t> pos_cache;
+    pos_cache.reserve(m_vBeads.size());
+    for(cBeadVectorIterator iterBead1 = m_vBeads.begin(); iterBead1!=m_vBeads.end(); ++iterBead1){
+        const auto &b=**iterBead1;
+        bead_info_t bi{
+            { (float)b.GetXPos(), (float)b.GetYPos(), (float)b.GetZPos()},
+            enoCache[b.GetType()]
+        };
+        pos_cache.push_back(bi);
+    }
+    
+    float QMin = m_QMin;
+    float dQ = m_dQ;
+
+    using histogram_pair_t = std::pair<std::vector<float>,std::vector<float>>;
+
+    histogram_pair_t init{
+        std::vector<float>(m_QPoints, 0),
+        std::vector<float>(m_QPoints, 0)
+    };
+
+    auto transform=[&](const bead_info_t &b1 ) -> histogram_pair_t
+    {
+        unsigned i1 = &b1 - &pos_cache[0];
+
+        // Malloc is not technically illegal in C++ parallel algorithms I think.
+        // Not sure how else to do it though.
+        std::vector<float> vIQLocal(m_QPoints, 0.0f);
+        std::vector<float> vIQSqLocal(m_QPoints, 0.0f);
+
+        const float esquare=b1.eno*b1.eno;
+        for(long iq = 0; iq < m_QPoints; ++iq)
+        {
+            vIQLocal[iq] += esquare;
+            vIQSqLocal[iq] += (esquare*esquare);
+        }
+
+        for(unsigned i2=i1+1; i2<pos_cache.size(); i2++){
+            const auto &b2=pos_cache[i2];
+    
+            // We multiply by 2 here as this only does (i1<i2), so we need to double it to cover (i2<i1)
+            // (i1==i2) is covered by the earlier special-case loop
+            const float eprod = 2 * b1.eno * b2.eno;
+            const float dr = DistanceMetric(b1.x, b2.x);
+              
+            if(dr > 0.000001)
+            {
+                // We are evaluating sin(ß (QMin+iq*dQ)*dr )
+                //                         sin( QMin*dr + iq*(dQ*dr) )
+                sin_enum_angle_recurrence sin_enum(QMin*dr, dQ*dr);    
+                float qvalue=QMin;
+                float scale=eprod / dr;
+                for(long iq = 0; iq < m_QPoints; iq++)
+                {
+                    const float dvalue = scale*sin_enum() / qvalue;
+                    // Accumulation is still double-precision
+                    vIQLocal[iq] += dvalue;
+                    vIQSqLocal[iq] += dvalue*dvalue;
+                    qvalue += dQ;
+                }
+            }
+            else
+            {
+                // i = j here so we have the same bead, and because Sinx/x = 1 when x = 0, the contribution is just F(q)**2.                
+                for(long iq = 0; iq < m_QPoints; ++iq)
+                {
+                    vIQLocal[iq] += eprod;
+                    vIQSqLocal[iq] += (eprod*eprod);
+                }
+            }
+        }
+
+        return {vIQLocal, vIQSqLocal};
+    };
+
+    auto reduce = [&](const histogram_pair_t &a, const histogram_pair_t &b) -> histogram_pair_t
+    {
+        histogram_pair_t res=a;
+        for(unsigned i=0; i<m_QPoints; i++){
+            res.first[i] += b.first[i];
+            res.second[i] += b.second[i];
+        }
+        return res;
+    };
+
+    histogram_pair_t res=std::transform_reduce(
+        //std::execution::par,
+        pos_cache.begin(), pos_cache.end(), 
+        init,
+        reduce,
+        transform        
+    );
+
+    for(unsigned i=0; i<m_QPoints; i++){
+        m_vIQ[i] += res.first[i];
+        m_vIQSq[i] += res.second[i];
+    }
+}
+#endif
+
+
+void prSAXS::UpdateState_InnerLoop_v4_threads(CSimState& rSimState, const ISimBox* const pISimBox)
+{        
+    // Define the min and max q values from the box size and bead diameter.
+
+    // Loop over all q values, adding the contributions from each bead pair weighted by their electon numbers.
+    // To svoid double counting, we start the second loop with the iterator equal to the first.
+
+    const auto &bead_types=rSimState.GetBeadTypes();
+    std::vector<float> enoCache(bead_types.size());
+    for(unsigned i=0; i<bead_types.size(); i++){
+        const auto pbt=bead_types[i];
+        assert(pbt->GetType()==i);
+        auto it= m_mElectronNo.find(i);
+        if(it!=m_mElectronNo.end()){
+            enoCache[i]=it->second;
+        }
+    }
+
+    struct bead_info_t
+    {
+        float x[3];
+        float eno;
+    };
+
+    std::vector<bead_info_t> pos_cache;
+    pos_cache.reserve(m_vBeads.size());
+    for(cBeadVectorIterator iterBead1 = m_vBeads.begin(); iterBead1!=m_vBeads.end(); ++iterBead1){
+        const auto &b=**iterBead1;
+        bead_info_t bi{
+            { (float)b.GetXPos(), (float)b.GetYPos(), (float)b.GetZPos()},
+            enoCache[b.GetType()]
+        };
+        pos_cache.push_back(bi);
+    }
+    
+    float QMin = m_QMin;
+    float dQ = m_dQ;
+
+    using histogram_pair_t = std::pair<std::vector<float>,std::vector<float>>;
+
+    histogram_pair_t init{
+        std::vector<float>(m_QPoints, 0),
+        std::vector<float>(m_QPoints, 0)
+    };
+
+    std::mutex mutex;
+    std::atomic<unsigned> i1_next;
+    i1_next = 0;
+
+    auto worker_prov = [&]() -> void
+    {
+        std::vector<float> vIQLocal(m_QPoints, 0.0f);
+        std::vector<float> vIQSqLocal(m_QPoints, 0.0f);
+
+        while(1){
+            unsigned i1=i1_next.fetch_add(1);
+            if(i1 >= pos_cache.size()){
+                return;
+            }
+
+            const auto &b1 = pos_cache[i1];
+
+            const float esquare=b1.eno*b1.eno;
+            for(long iq = 0; iq < m_QPoints; ++iq)
+            {
+                vIQLocal[iq] += esquare;
+                vIQSqLocal[iq] += (esquare*esquare);
+            }
+
+            for(unsigned i2=i1+1; i2<pos_cache.size(); i2++){
+                const auto &b2=pos_cache[i2];
+        
+                // We multiply by 2 here as this only does (i1<i2), so we need to double it to cover (i2<i1)
+                // (i1==i2) is covered by the earlier special-case loop
+                const float eprod = 2 * b1.eno * b2.eno;
+                const float dr = DistanceMetric(b1.x, b2.x);
+                
+                if(dr > 0.000001)
+                {
+                    // We are evaluating sin(ß (QMin+iq*dQ)*dr )
+                    //                         sin( QMin*dr + iq*(dQ*dr) )
+                    sin_enum_angle_recurrence sin_enum(QMin*dr, dQ*dr);    
+                    float qvalue=QMin;
+                    float scale=eprod / dr;
+                    for(long iq = 0; iq < m_QPoints; iq++)
+                    {
+                        const float dvalue = scale*sin_enum() / qvalue;
+                        // Accumulation is still double-precision
+                        vIQLocal[iq] += dvalue;
+                        vIQSqLocal[iq] += dvalue*dvalue;
+                        qvalue += dQ;
+                    }
+                }
+                else
+                {
+                    // i = j here so we have the same bead, and because Sinx/x = 1 when x = 0, the contribution is just F(q)**2.                
+                    for(long iq = 0; iq < m_QPoints; ++iq)
+                    {
+                        vIQLocal[iq] += eprod;
+                        vIQSqLocal[iq] += (eprod*eprod);
+                    }
+                }
+            }
+
+            {
+                std::unique_lock<std::mutex> lk(mutex);
+                for(unsigned i=0; i<m_QPoints; i++){
+                    m_vIQ[i] += vIQLocal[i];
+                    m_vIQSq[i] += vIQSqLocal[i];
+                    vIQLocal[i] = 0;
+                    vIQSqLocal[i] = 0;
+                }
+            }    
+        }
+    };
+
+
+
+    std::vector<std::thread> workers;
+    unsigned numthreads=std::thread::hardware_concurrency();
+    numthreads=std::max<unsigned>(1, numthreads-1);
+    for(unsigned i=0; i<numthreads; i++){
+        workers.push_back(std::thread(worker_prov));
+    }
+
+    for(unsigned i=0; i<numthreads; i++){
+        workers[i].join();
+    }
+}
+
+/*
+void prSAXS::UpdateState_InnerLoop_v3(CSimState& rSimState, const ISimBox* const pISimBox)
+{        
+    #error "Not complete. WIP"
+
+    // Define the min and max q values from the box size and bead diameter.
+
+    // Loop over all q values, adding the contributions from each bead pair weighted by their electon numbers.
+    // To svoid double counting, we start the second loop with the iterator equal to the first.
+
+    const auto &bead_types=rSimState.GetBeadTypes();
+    unsigned ntypes=bead_types.size();
+
+    std::vector<float> enoCache(ntypes);
+    for(unsigned i=0; i<ntypes; i++){
+        const auto pbt=bead_types[i];
+        assert(pbt->GetType()==i);
+        enoCache[i]=m_mElectronNo.at(i);
+    }
+
+    float drMax = sqrt(std::pow(pISimBox->GetSimBoxXLength(),2) + std::pow(pISimBox->GetSimBoxYLength(),2) + std::pow(pISimBox->GetSimBoxZLength(),2)); 
+    float drQuant = 0.01;
+    float drQuantInv = 1.0/drQuant;
+    unsigned drQuantMax = std::ceil( drMax * drQuantInv ) + 1;
+
+    std::vector<std::vector<uint64_t>> histograms;
+    for(unsigned i1=0; i1+1<ntypes; i1++){
+        for(unsigned i2=i1+1; i2<ntypes; i2++){
+            histograms[i1*ntypes+i2].resize( drQuantMax );
+        }
+    }
+
+    struct bead_info_t
+    {
+        float x[3];
+        uint32_t type;
+    };
+
+    std::vector<unsigned> type_counts(ntypes, 0);
+
+    std::vector<bead_info_t> pos_cache;
+    pos_cache.reserve(m_vBeads.size());
+    for(cBeadVectorIterator iterBead1 = m_vBeads.begin(); iterBead1!=m_vBeads.end(); ++iterBead1){
+        const auto &b=**iterBead1;
+        bead_info_t bi{
+            { (float)b.GetXPos(), (float)b.GetYPos(), (float)b.GetZPos()},
+            b.GetType()
+        };
+        pos_cache.push_back(bi);
+
+        type_counts[bi.type] += 1;
+    }
+    
+    float QMin = m_QMin;
+    float dQ = m_dQ;
+
+    for(unsigned i1=0; i1<pos_cache.size(); i1++){
+        const auto &b1=pos_cache[i1];
+
+        for(unsigned i2=i1+1; i2<pos_cache.size(); i2++){
+            const auto &b2=pos_cache[i2];
+
+            unsigned type_min=std::min(b1.type,b2.type);
+            unsigned type_max=std::max(b1.type,b2.type);
+            unsigned type_type_index=type_min * ntypes + type_max;
+
+            const float dr = DistanceMetric(b1.x, b2.x);
+            const unsigned drq = unsigned( dr * drQuantInv );
+
+            histograms[type_type_index][drq] += 1;
+        }
+    }
+
+    for(unsigned i1=0; i1+1<ntypes; i1++){
+        for(unsigned i2=i1+1; i2<ntypes; i2++){
+            
+
+            histograms[i1*ntypes+i2].resize( drQuantMax );
+        }
+    }
+}
+*/
 
 // Function to check that the user-specified data is valid and. As this process
 // is internally generated by the shadow SimBox we do not perform validity checking.

--- a/src/prSAXS.h
+++ b/src/prSAXS.h
@@ -13,6 +13,7 @@ class CSimState;
 
 #include "xxProcess.h"
 
+
 class prSAXS : public xxProcess
 {
 	// ****************************************
@@ -90,6 +91,21 @@ protected:
 	// ****************************************
 	// Private functions
 
+	void UpdateState_InnerLoop_ref(CSimState& rSimState, const ISimBox* const pISimBox);
+	void UpdateState_InnerLoop_v1(CSimState& rSimState, const ISimBox* const pISimBox);
+	void UpdateState_InnerLoop_v2(CSimState& rSimState, const ISimBox* const pISimBox);
+	void UpdateState_InnerLoop_v3(CSimState& rSimState, const ISimBox* const pISimBox);
+	void UpdateState_InnerLoop_v4(CSimState& rSimState, const ISimBox* const pISimBox);
+	void UpdateState_InnerLoop_v4_threads(CSimState& rSimState, const ISimBox* const pISimBox);
+	#if OSPREY_DPD_HAVE_OPENMP
+	void UpdateState_InnerLoop_v4_omp(CSimState& rSimState, const ISimBox* const pISimBox);
+	#endif
+	#if OSPREY_DPD_HAVE_STL_PARALLEL
+	void UpdateState_InnerLoop_v4_stl_parallel(CSimState& rSimState, const ISimBox* const pISimBox);
+	#endif
+
+	double DistanceMetric(const CAbstractBead *a, const CAbstractBead *b) const;
+	float DistanceMetric(const float *a, const float *b) const;
 
 	// ****************************************
 	// Data members


### PR DESCRIPTION
Faster implementations of prSAXS::UpdateState, courtesy of Kind Charles' bank holiday.
There is a sequence of implementations, with the fastest one using a combination of loop
transformations and native threads. The file `examples/dmpci.micelles-SAXS` is the test
example used to drive it.

On my Apple M2 laptop (8 cores, 4xperformance, 4xefficiency):
- Original: 362.014 secs
- Optimised: 6.34 secs
- Speedup: ~58 times

The pull request also contains a commit removing some constructs which were removed
in C++17, as I was playing around with the STL parallel functions which are C++17. However,
OSX clang is a bit weak (no OpenMP, no STL parallel), so I gave up on that direction. If
preferred, the C++17 changes could be removed.