### PR TITLE
Support for "PovrayWithBonds" snapshot format which shows bonds

### DIFF
--- a/src/CurrentState.cpp
+++ b/src/CurrentState.cpp
@@ -23,6 +23,8 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 #include "ISimBox.h"
 #include "InputData.h"
 #include "Bead.h"
+#include "Polymer.h"
+#include "Bond.h"
 
 // **********************************************************************
 // Global Functions and members
@@ -112,6 +114,7 @@ CCurrentState::CCurrentState(const long currentTime, const zString runId,
                              double xmax, double ymax, double zmax) : xxState(xxBase::GetCSPrefix() + runId + ".con." + ToString(currentTime) + pFormat->GetFileExtension(), true, currentTime, runId),
 															 m_pFormat(pFormat),
 															 m_vAllBeads(pISimBox->GetBeads()),
+															 m_vAllPolymers(pISimBox->GetPolymers()),
 															 m_bRestrictCoords(bRestrictCoords),
 															 m_SimBoxXLength(pISimBox->GetSimSpaceXLength()),
 															 m_SimBoxYLength(pISimBox->GetSimSpaceYLength()),
@@ -217,6 +220,20 @@ bool CCurrentState::Serialize()
 
 				if(!m_outStream.good())
 					return IOError("Error writing CurrentState data to file");
+			}
+		}
+	}
+
+	if(m_pFormat->UsesBonds()){
+		for(const CPolymer *polymer : m_vAllPolymers){
+			for(const CBond *bond : polymer->GetBonds()){
+				const auto *head=bond->GetHead();
+				const auto *tail=bond->GetTail();
+				if(!(head->GetVisible()&&tail->GetVisible())){
+					continue;
+				}
+				
+				m_pFormat->SerializeBond(m_outStream, *polymer, *bond);
 			}
 		}
 	}

--- a/src/CurrentState.h
+++ b/src/CurrentState.h
@@ -97,6 +97,7 @@ private:
 	// that may have moved between processors
 
 	const AbstractBeadVector	m_vAllBeads;
+	const PolymerVector	       m_vAllPolymers;
 
 	StringSequence				m_BeadNames;
 	StringSequence				m_BeadColours;

--- a/src/CurrentStateFormat.cpp
+++ b/src/CurrentStateFormat.cpp
@@ -93,6 +93,12 @@ CCurrentStateFormat::~CCurrentStateFormat()
 
 }
 
+// Default behaviour is that formats don't need to know about bonds
+bool CCurrentStateFormat::UsesBonds() const
+{
+	return false;
+}
+
 // Protected function that returns a named colour given a numeric bead type.
 // If the type is larger than the colour array, we return the first entry.
 
@@ -108,6 +114,7 @@ const zString CCurrentStateFormat::GetBeadColourFromType(long beadType) const
     }
 }
 
+
 // Do-nothing implementation of the function to write out snapshot information 
 // following the bead data. Not all formats require this, so we make it a
 // non-pure virtual function. Any derived class that wants to use it must
@@ -115,5 +122,9 @@ const zString CCurrentStateFormat::GetBeadColourFromType(long beadType) const
 
 void CCurrentStateFormat::SerializeFooter(zOutStream& os, const long beadTotal)
 {
+}
 
+// Do-nothing implementation.
+void CCurrentStateFormat::SerializeBond(zOutStream& os, const CPolymer &polymer, const CBond &bond)
+{
 }

--- a/src/CurrentStateFormat.h
+++ b/src/CurrentStateFormat.h
@@ -31,11 +31,15 @@ public:
 
 	virtual const zString GetFileExtension() const = 0;
 
+	// Return true if this format needs to know about bonds
+	virtual bool UsesBonds() const;
+
 	// Function to ensure that derived classes can write their data to file
 
 	virtual void SerializeHeader(zOutStream& os, const long beadTotal) = 0;
 	virtual void SerializeBead(zOutStream& os, const zString name, const long type, const double radius,
 								const double x, const double y, const double z) = 0;
+	virtual void SerializeBond(zOutStream& os, const CPolymer &polymer, const CBond &bond);
 	virtual void SerializeFooter(zOutStream& os, const long beadTotal);
 
 	// ****************************************

--- a/src/Monitor.cpp
+++ b/src/Monitor.cpp
@@ -1499,6 +1499,12 @@ void CMonitor::SaveCurrentState()
 								    m_bDisplayBox, m_BeadTypeSize, 
 									m_Camera, m_Target, m_vLightX, m_vLightY, m_vLightZ);
 	}
+	else if( m_DefaultCurrentStateFormat == "PovrayWithBonds" )
+	{
+		pFormat = new CPovrayFormat(m_SimBoxXLength, m_SimBoxYLength, m_SimBoxZLength,
+								    m_bDisplayBox, m_BeadTypeSize, 
+									m_Camera, m_Target, m_vLightX, m_vLightY, m_vLightZ, true);
+	}
 	else if( m_DefaultCurrentStateFormat == "Amira" )
 	{
 		pFormat = new CAmiraFormat(m_SimBoxXLength, m_SimBoxYLength, m_SimBoxZLength,

--- a/src/Polymer.h
+++ b/src/Polymer.h
@@ -66,6 +66,7 @@ public:
 	inline CAbstractBead*    GetTail() const	 {return m_pTail;}
 	inline BeadVector& GetBeads()			     {return m_vBeads;}
 	inline BondVector& GetBonds()			     {return m_vBonds;}
+	inline const BondVector& GetBonds() const    {return m_vBonds;}
 	inline BondPairVector& GetBondPairs()        {return m_vBondPairs;}
 
 	// Function to return a third bead in the polymer apart from its Head and Tail

--- a/src/PovrayFormat.h
+++ b/src/PovrayFormat.h
@@ -19,7 +19,8 @@ public:
 				  const double camera[3], const double target[3],
 				 zDoubleVector vLightX, 
 				 zDoubleVector vLightY, 
-				 zDoubleVector vLightZ);
+				 zDoubleVector vLightZ,
+				 bool showBonds = false);
 
 	virtual ~CPovrayFormat();
 
@@ -39,11 +40,16 @@ public:
 	// PVFs that must be overridden by all derived classes
 public:
 
+	virtual bool UsesBonds() const
+	{ return m_ShowBonds; }
+
 	// Function to ensure that derived classes can write their data to file
 
 	virtual void SerializeHeader(zOutStream& os, const long beadTotal);
 	virtual void SerializeBead(zOutStream& os, const zString name, const long type, const double radius,
 								const double x, const double y, const double z);
+	virtual void SerializeBond(zOutStream& os, const CPolymer &polymer, const CBond &bond);
+
 
 	// ****************************************
 	// Protected local functions
@@ -70,6 +76,7 @@ private:
 	zDoubleVector m_vLightY;
 	zDoubleVector m_vLightZ;
 
+	bool m_ShowBonds;  // Whether to show bonds as rods
 };
 
 #endif // !defined(AFX_POVRAYFORMAT_H__6F3CE7F1_0496_4F06_B901_F538D979EDC5__INCLUDED_)

--- a/src/mcSetCurrentStateDefaultFormatImpl.cpp
+++ b/src/mcSetCurrentStateDefaultFormatImpl.cpp
@@ -61,6 +61,15 @@ void mcSetCurrentStateDefaultFormatImpl::SetCurrentStateDefaultFormat(const xxCo
 		    new CLogSetCurrentStateDefaultFormat(pMon->GetCurrentTime(), pMon->m_DefaultCurrentStateFormat);
         }
 	}
+	else if(format == "PovrayWithBonds")
+	{
+		pMon->m_DefaultCurrentStateFormat = "PovrayWithBonds";
+
+        if(xxParallelBase::GlobalGetRank() == 0)
+        {
+		    new CLogSetCurrentStateDefaultFormat(pMon->GetCurrentTime(), pMon->m_DefaultCurrentStateFormat);
+        }
+	}
 	else if(format == "Amira")
 	{
 		pMon->m_DefaultCurrentStateFormat = "Amira";
@@ -94,6 +103,12 @@ void mcSetCurrentStateDefaultFormatImpl::SetCurrentStateDefaultFormat(const xxCo
 	if(format == "Povray")
 	{
 		pMon->m_DefaultCurrentStateFormat = "Povray";
+
+		new CLogSetCurrentStateDefaultFormat(pMon->GetCurrentTime(), pMon->m_DefaultCurrentStateFormat);
+	}
+	else if(format == "PovrayWithBonds")
+	{
+		pMon->m_DefaultCurrentStateFormat = "PovrayWithBonds";
 
 		new CLogSetCurrentStateDefaultFormat(pMon->GetCurrentTime(), pMon->m_DefaultCurrentStateFormat);
 	}


### PR DESCRIPTION
This adds a new state format called "PovrayWithBonds". This is based on the existing "Povray" format, but
it adds cylinders/rods to show bonds between beads, while making the beads smaller so that the
rods can be seen. I've found it useful when trying to work out how polymers are interacting in more complicated
structures.

The generated povray file contains three definitions in the header which control
the sticks:
```
#declare BeadRadiusScale = 0.4; 
#declare BondStickColour = Black; 
#declare BondStickRadius = 0.09; 
```
Currently they are mainly for manual tweaking while rendering to get the most understandable version,
and aren't exposed as tweakable parameters in the dmpci.

Attached are rendered versions of the the same dmpci file:

Default:
![dmpccs bilayer con 100-no-bonds](https://github.com/Osprey-DPD/osprey-dpd/assets/3024705/2d7856f3-f826-4eb8-9e3b-a7c514fe321b)

With "Command SetCurrentStateDefaultFormat 1 PovrayWithBonds" : 
![dmpccs bilayer con 100-bonds](https://github.com/Osprey-DPD/osprey-dpd/assets/3024705/fbc9124b-3cc9-483f-a029-559e9926f74e)

With povray file modified for BeadRadiusScale = 0.3 and BondStickRadius = 0.05:
![dmpccs bilayer con 100-thin-bonds](https://github.com/Osprey-DPD/osprey-dpd/assets/3024705/6cce2c5d-eab3-4446-a79a-dca0c305d5ed)
